### PR TITLE
chore(hooks): dont apply and stage in pre-commit

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn d2-style apply && git add -u
+yarn d2-style check --staged


### PR DESCRIPTION
`pre-commit` hook should not apply or (at least) not stage changes. This causes all unstaged changes to be part of the commit. 

Default hook template in `cli-style` just runs check: https://github.com/dhis2/aggregate-data-entry-app/blob/master/.hooks/pre-commit