### PR TITLE
fix(layout): support fixed footer

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-07-31T08:48:00.070Z\n"
-"PO-Revision-Date: 2023-07-31T08:48:00.070Z\n"
+"POT-Creation-Date: 2023-07-31T11:36:19.094Z\n"
+"PO-Revision-Date: 2023-07-31T11:36:19.094Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -622,12 +622,6 @@ msgstr "Domain (required)"
 
 msgid "A data element can either be aggregated or tracked data."
 msgstr "A data element can either be aggregated or tracked data."
-
-msgid "aggregate"
-msgstr "aggregate"
-
-msgid "tracker"
-msgstr "tracker"
 
 msgid "Metadata management"
 msgstr "Metadata management"

--- a/src/app/layout/Layout.module.css
+++ b/src/app/layout/Layout.module.css
@@ -39,6 +39,13 @@
     height: 0px;
 }
 
+.footerPlaceholder {
+    grid-area: footer;
+    width: 100vw;
+    padding: var(--spacers-dp16) 0;
+    background: var(--colors-white);
+}
+
 @media m-medium {
     .wrapper {
         height: 100%;

--- a/src/app/layout/Layout.module.css
+++ b/src/app/layout/Layout.module.css
@@ -17,7 +17,7 @@
 }
 .wrapperWithFooter {
     composes: wrapper;
-    grid-template-areas: 'sidebar main' 'footer footer';
+    grid-template-areas: 'sidebar' 'main' 'footer';
     grid-template-rows: auto 1fr 68px;
     overflow-y: auto;
 }

--- a/src/app/layout/Layout.module.css
+++ b/src/app/layout/Layout.module.css
@@ -15,9 +15,16 @@
     grid-template-rows: auto 1fr;
     overflow: auto;
 }
+.wrapperWithFooter {
+    composes: wrapper;
+    grid-template-areas: 'sidebar main' 'footer footer';
+    grid-template-rows: auto 1fr 68px;
+    overflow-y: auto;
+}
 
 .main {
-    padding: 16px;
+    padding: var(--spacers-dp16);
+    padding-bottom: 0px;
     grid-area: main;
     background-color: var(--colors-grey100);
     width: 100%;
@@ -39,6 +46,10 @@
         grid-template-columns: auto 1fr;
         grid-template-rows: none;
         grid-template-areas: 'sidebar   main';
+    }
+    .wrapperWithFooter {
+        grid-template-areas: 'sidebar main' 'footer footer';
+        grid-template-rows: 1fr 68px;
     }
     .sidebar {
         width: 240px;

--- a/src/app/layout/Layout.tsx
+++ b/src/app/layout/Layout.tsx
@@ -8,11 +8,16 @@ import css from './Layout.module.css'
 interface BaseLayoutProps {
     children: React.ReactNode
     sidebar?: React.ReactNode
+    showFooter?: boolean
 }
 
-export const BaseSidebarLayout = ({ children, sidebar }: BaseLayoutProps) => {
+export const BaseLayout = ({
+    children,
+    sidebar,
+    showFooter,
+}: BaseLayoutProps) => {
     return (
-        <div className={css.wrapper}>
+        <div className={showFooter ? css.wrapperWithFooter : css.wrapper}>
             {sidebar}
             <div className={css.main}>{children}</div>
         </div>
@@ -22,12 +27,15 @@ export const BaseSidebarLayout = ({ children, sidebar }: BaseLayoutProps) => {
 export const SidebarLayout = ({
     children,
     hideSidebar,
+    showFooter,
 }: {
     children: React.ReactNode
     hideSidebar?: boolean
+    showFooter?: boolean
 }) => {
     return (
-        <BaseSidebarLayout
+        <BaseLayout
+            showFooter={showFooter}
             sidebar={
                 <Sidebar
                     className={cx(css.sidebar, { [css.hide]: hideSidebar })}
@@ -35,7 +43,7 @@ export const SidebarLayout = ({
             }
         >
             {children}
-        </BaseSidebarLayout>
+        </BaseLayout>
     )
 }
 
@@ -44,9 +52,10 @@ export const Layout = () => {
     // routes can specify a handle to hide the sidebar
     // hide the sidebar if any matched route specifies it
     const hideSidebar = matches.some((match) => match.handle?.hideSidebar)
+    const showFooter = matches.some((match) => match.handle?.showFooter)
 
     return (
-        <SidebarLayout hideSidebar={hideSidebar}>
+        <SidebarLayout hideSidebar={hideSidebar} showFooter={showFooter}>
             <Outlet />
         </SidebarLayout>
     )

--- a/src/app/layout/Layout.tsx
+++ b/src/app/layout/Layout.tsx
@@ -20,6 +20,7 @@ export const BaseLayout = ({
         <div className={showFooter ? css.wrapperWithFooter : css.wrapper}>
             {sidebar}
             <div className={css.main}>{children}</div>
+            {showFooter && <div className={css.footerPlaceholder}></div>}
         </div>
     )
 }

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -97,7 +97,7 @@ const schemaSectionRoutes = Object.values(SCHEMA_SECTIONS).map((section) => (
         handle={{ section }}
     >
         <Route index lazy={createSectionLazyRouteFunction(section, 'List')} />
-        <Route handle={{ hideSidebar: true, showFooter: true }}>
+        <Route handle={{ hideSidebar: true }}>
             {!sectionsNoNewRoute.has(section) && (
                 <Route
                     path={routePaths.sectionNew}

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -107,6 +107,7 @@ const schemaSectionRoutes = Object.values(SCHEMA_SECTIONS).map((section) => (
             <Route path=":id" element={<VerifyModelId />}>
                 <Route
                     index
+                    handle={{ showFooter: true }}
                     lazy={createSectionLazyRouteFunction(section, 'Edit')}
                 ></Route>
             </Route>

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -97,7 +97,7 @@ const schemaSectionRoutes = Object.values(SCHEMA_SECTIONS).map((section) => (
         handle={{ section }}
     >
         <Route index lazy={createSectionLazyRouteFunction(section, 'List')} />
-        <Route handle={{ hideSidebar: true }}>
+        <Route handle={{ hideSidebar: true, showFooter: true }}>
             {!sectionsNoNewRoute.has(section) && (
                 <Route
                     path={routePaths.sectionNew}

--- a/src/app/routes/types.ts
+++ b/src/app/routes/types.ts
@@ -10,6 +10,7 @@ type MatchWithHandle<THandle> = ReturnType<typeof useMatches>[number] & {
 // common type for possible handle-properties used in Route
 export type RouteHandle = {
     hideSidebar?: boolean
+    showFooter?: boolean
     section?: SchemaSection
 }
 

--- a/src/pages/dataElements/New.module.css
+++ b/src/pages/dataElements/New.module.css
@@ -1,14 +1,6 @@
 .container {
-    display: block;
-    height: 100%;
-    position: relative;
-    overflow: hidden;
-    overflow-y: auto;
     box-sizing: border-box;
-}
-
-.form {
-    padding-bottom: 68px;
+    height: 100%;
 }
 
 .formActions {
@@ -17,6 +9,6 @@
     bottom: 0;
     width: 100vw;
     padding: var(--spacers-dp16) 0;
-    box-shadow: 0 0 3px rgba(0,0,0,0.8);
+    box-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
     background: var(--colors-white);
 }


### PR DESCRIPTION
Adds support for a footer in `layout`. Previously the `scrollbar` would disappear under the footer if a fixed footer was rendered. Note that this just intended to "reserve" the space in the grid, and the intention is that the form should render a `position: fixed`- component at the bottom of the page. The reason for this is that it's annoying to form-controls outside of the form. 