### PR TITLE
fix(sectionlist): add page title

### DIFF
--- a/src/app/layout/Layout.module.css
+++ b/src/app/layout/Layout.module.css
@@ -32,6 +32,13 @@
     height: 0px;
 }
 
+.pageTitle {
+    font-size: 28px;
+    color: var(--colors-grey900);
+    line-height: 40px;
+    padding-bottom: 16px;
+}
+
 @media m-medium {
     .wrapper {
         height: 100%;

--- a/src/app/layout/PageTitle.tsx
+++ b/src/app/layout/PageTitle.tsx
@@ -1,0 +1,6 @@
+import React, { PropsWithChildren } from 'react'
+import css from './Layout.module.css'
+
+export const PageTitle = ({ children }: PropsWithChildren) => {
+    return <div className={css.pageTitle}>{children}</div>
+}

--- a/src/app/layout/index.tsx
+++ b/src/app/layout/index.tsx
@@ -1,1 +1,2 @@
 export { Layout, SidebarLayout } from './Layout'
+export * from './PageTitle'

--- a/src/components/sectionList/SectionListTitle.tsx
+++ b/src/components/sectionList/SectionListTitle.tsx
@@ -1,0 +1,17 @@
+import i18n from '@dhis2/d2-i18n'
+import React from 'react'
+import { PageTitle } from '../../app/layout/PageTitle'
+import { useSectionHandle } from '../../lib'
+
+export const SectionListTitle = () => {
+    const section = useSectionHandle()
+    if (!section) {
+        return null
+    }
+
+    return (
+        <PageTitle>
+            {i18n.t('{{modelName}} management', { modelName: section.title })}
+        </PageTitle>
+    )
+}

--- a/src/components/sectionList/SectionListWrapper.tsx
+++ b/src/components/sectionList/SectionListWrapper.tsx
@@ -7,6 +7,7 @@ import { SectionListLoader } from './SectionListLoader'
 import { SectionListEmpty, SectionListError } from './SectionListMessages'
 import { SectionListPagination } from './SectionListPagination'
 import { SectionListRow } from './SectionListRow'
+import { SectionListTitle } from './SectionListTitle'
 import { SelectionListHeader } from './SelectionListHeaderNormal'
 import { SelectedColumns } from './types'
 
@@ -74,6 +75,7 @@ export const SectionListWrapper = <Model extends IdentifiableObject>({
 
     return (
         <div>
+            <SectionListTitle />
             <FilterWrapper>{filterElement}</FilterWrapper>
             <SelectionListHeader />
             <SectionList


### PR DESCRIPTION

Implements `PageTitle` for `SectionList`. I was a bit unsure if this should've been another `handle`, and thus tied to the route. However, I think it might be more flexible composing it in the components that render it. Since for `Edit`-routes, the title depends on the object being edited (eg. `Edit: ANC 1st visit`). However, it comes with the downside of having to "manually" add these to the "wrapper"-components. 