### PR TITLE
fix(form): fix editing style object

### DIFF
--- a/src/pages/dataElements/Edit.tsx
+++ b/src/pages/dataElements/Edit.tsx
@@ -116,7 +116,7 @@ function usePatchDirtyFields() {
         const jsonPatchPayload = createJsonPatchOperations({
             values,
             dirtyFields,
-            dataElement,
+            originalValue: dataElement,
         })
 
         // We want the promise so we know when submitting is done. The promise

--- a/src/pages/dataElements/edit/createJsonPatchOperations.spec.ts
+++ b/src/pages/dataElements/edit/createJsonPatchOperations.spec.ts
@@ -105,7 +105,7 @@ describe('createJsonPatchOperations', () => {
                 originalValue: {
                     id: 'foo',
                     name: 'bar',
-                    attributeValues: [],
+                    attributeValues: [{ value: '', attribute: 'foo' }],
                 },
                 values: {
                     name: 'baz',

--- a/src/pages/dataElements/edit/createJsonPatchOperations.spec.ts
+++ b/src/pages/dataElements/edit/createJsonPatchOperations.spec.ts
@@ -1,0 +1,127 @@
+import {
+    sanitizeDirtyValueKeys,
+    createJsonPatchOperations,
+} from './createJsonPatchOperations'
+
+describe('createJsonPatchOperations', () => {
+    describe('sanitizeDirtyValueKeys', () => {
+        it('should return the dirty values array as is', () => {
+            const actual = sanitizeDirtyValueKeys(['foo', 'bar'])
+            const expected = ['foo', 'bar']
+            expect(actual).toEqual(expected)
+        })
+
+        it('should remove all attribute values changes and add a single "attributeValues"', () => {
+            const actual = sanitizeDirtyValueKeys([
+                'foo',
+                'bar',
+                'attributeValues[0].value',
+                'attributeValues[1].value',
+            ])
+            const expected = ['foo', 'bar', 'attributeValues']
+            expect(actual).toEqual(expected)
+        })
+
+        it('should remove style.icon and style.color changes and add a single "style"', () => {
+            const actual = sanitizeDirtyValueKeys([
+                'foo',
+                'bar',
+                'style.color',
+                'style.icon',
+            ])
+            const expected = ['foo', 'bar', 'style']
+            expect(actual).toEqual(expected)
+        })
+    })
+
+    describe('createJsonPatchOperations', () => {
+        it('should return an empty array if no dirty fields', () => {
+            const actual = createJsonPatchOperations({
+                dirtyFields: {},
+                originalValue: {
+                    id: 'foo',
+                    attributeValues: [],
+                },
+                values: {
+                    attributeValues: [],
+                },
+            })
+            expect(actual).toEqual([])
+        })
+
+        it('should return a json-patch payload for a single field', () => {
+            const actual = createJsonPatchOperations({
+                dirtyFields: {
+                    name: true,
+                },
+                originalValue: {
+                    id: 'foo',
+                    name: 'bar',
+                    attributeValues: [],
+                },
+                values: {
+                    name: 'baz',
+                    attributeValues: [],
+                },
+            })
+            const expected = [
+                {
+                    op: 'replace',
+                    path: '/name',
+                    value: 'baz',
+                },
+            ]
+            expect(actual).toEqual(expected)
+        })
+        it('should return a json-patch payload with add if value does not exist in originalValue', () => {
+            const actual = createJsonPatchOperations({
+                dirtyFields: {
+                    name: true,
+                },
+                originalValue: {
+                    id: 'foo',
+                    attributeValues: [],
+                },
+                values: {
+                    name: 'baz',
+                    attributeValues: [],
+                },
+            })
+            const expected = [
+                {
+                    op: 'add',
+                    path: '/name',
+                    value: 'baz',
+                },
+            ]
+            expect(actual).toEqual(expected)
+        })
+
+        it('should handle attributeValues', () => {
+            const actual = createJsonPatchOperations({
+                dirtyFields: {
+                    attributeValues: true,
+                },
+                originalValue: {
+                    id: 'foo',
+                    name: 'bar',
+                    attributeValues: [],
+                },
+                values: {
+                    name: 'baz',
+                    attributeValues: [
+                        { value: 'INPUT', attribute: { id: 'foo' } },
+                    ],
+                },
+            })
+            const expected = [
+                {
+                    op: 'replace',
+                    path: '/attributeValues',
+                    value: [{ value: 'INPUT', attribute: { id: 'foo' } }],
+                },
+            ]
+            expect(actual).toEqual(expected)
+        })
+    })
+})

--- a/src/pages/dataElements/edit/createJsonPatchOperations.ts
+++ b/src/pages/dataElements/edit/createJsonPatchOperations.ts
@@ -2,12 +2,12 @@ import get from 'lodash/fp/get'
 import { JsonPatchOperation } from '../../../types'
 import { Attribute, AttributeValue } from './../../../types/generated/models'
 
-type PatchAttributeFields = {
+type PatchAttribute = {
     id: Attribute['id']
 }
 
 type PatchAttributeValue = {
-    attribute: PatchAttributeFields
+    attribute: PatchAttribute
     value: AttributeValue['value']
 }
 


### PR DESCRIPTION
JSON-patch does not support patching nested fields in complex objects. So I added some logic to include that when "sanitizing" the keys - so they're sent together as a `style` object. 

EDIT:
Refactored and simplified `sanitizeDirtyValueKeys`
I've made the types a bit safer.
Also we sent too much information in attributes, simplified these to just send the id and value.

I do think we can use `schemas` and generalize this a bit more later. 
