### PR TITLE
fix(summarycard): adjust icon-less design

### DIFF
--- a/src/pages/overview/card/SummaryCard.module.css
+++ b/src/pages/overview/card/SummaryCard.module.css
@@ -1,31 +1,43 @@
 .cardGroup {
     display: grid;
     grid-template-columns: repeat(auto-fill, 320px);
-    grid-gap: var(--spacers-dp16);
+    grid-gap: var(--spacers-dp12);
 }
 
 .cardGroupHeader {
-    font-size: 22px;
-    padding: 12px 0;
+    font-size: 20px;
+    padding: var(--spacers-dp24) 0 var(--spacers-dp12) 0;
     color: var(--colors-grey900);
-    line-height: 40px;
+    line-height: 28px;
 }
 
 .cardWrapper {
     display: flex;
     flex-direction: column;
-    padding: 16px;
+    align-content: space-between;
     width: 320px;
     height: 100%;
+    background: var(--colors-white);
+    border-radius: 3px;
+    border: 1px solid var(--colors-grey400);
+}
+
+.cardTopLink {
+    padding: 12px;
+}
+
+.cardTopLink:hover .cardHeader {
+    text-decoration: underline;
 }
 
 .cardIcon svg {
     width: 32px;
     height: 32px;
+    display: none;
 }
 
 .cardHeader {
-    padding: 12px 0px;
+    padding: 0 0 6px 0;
     color: var(--colors-grey900);
     font-size: 16px;
     font-weight: 500;
@@ -43,9 +55,10 @@
 .cardActions {
     /* margin-auto pushes this to the bottom (extends margin to occupy extra space) */
     margin-top: auto;
-    padding-top: 12px;
+    padding: 8px 12px;
     display: flex;
     gap: var(--spacers-dp8);
+    border-top: 1px solid var(--colors-grey300);
 }
 
 .cardActions a {

--- a/src/pages/overview/card/SummaryCard.tsx
+++ b/src/pages/overview/card/SummaryCard.tsx
@@ -54,16 +54,20 @@ export const SummaryCard = ({
 }: SummaryCardProps) => {
     const title = section.title
     return (
-        <Card dataTest={`card-${title}`}>
+        <div data-test={`card-${title}`}>
             <div className={styles.cardWrapper}>
-                <Link to={`/${getSectionPath(section)}`}>
-                    <div className={styles.cardIcon}>{icon}</div>
-                    <SummaryCardHeader>{title}</SummaryCardHeader>
-                    <SummaryCardContent>{children}</SummaryCardContent>
+                <Link
+                    className={styles.cardTopLink}
+                    to={`/${getSectionPath(section)}`}
+                >
+                    <div className={styles.cardTop}>
+                        <SummaryCardHeader>{title}</SummaryCardHeader>
+                        <SummaryCardContent>{children}</SummaryCardContent>
+                    </div>
                 </Link>
                 <SummaryCardActions section={section} />
             </div>
-        </Card>
+        </div>
     )
 }
 

--- a/src/pages/overview/card/SummaryCard.tsx
+++ b/src/pages/overview/card/SummaryCard.tsx
@@ -54,19 +54,17 @@ export const SummaryCard = ({
 }: SummaryCardProps) => {
     const title = section.title
     return (
-        <div data-test={`card-${title}`}>
-            <div className={styles.cardWrapper}>
-                <Link
-                    className={styles.cardTopLink}
-                    to={`/${getSectionPath(section)}`}
-                >
-                    <div className={styles.cardTop}>
-                        <SummaryCardHeader>{title}</SummaryCardHeader>
-                        <SummaryCardContent>{children}</SummaryCardContent>
-                    </div>
-                </Link>
-                <SummaryCardActions section={section} />
-            </div>
+        <div data-test={`card-${title}`} className={styles.cardWrapper}>
+            <Link
+                className={styles.cardTopLink}
+                to={`/${getSectionPath(section)}`}
+            >
+                <div className={styles.cardTop}>
+                    <SummaryCardHeader>{title}</SummaryCardHeader>
+                    <SummaryCardContent>{children}</SummaryCardContent>
+                </div>
+            </Link>
+            <SummaryCardActions section={section} />
         </div>
     )
 }


### PR DESCRIPTION
This PR adjusts the summary card component design:
- removes `Card` usage (may be deprecated from UI, so will not start using here)
- removes icons (not adding value, can revisit if we want to spend time making many unique icons, but is a tough task.)
- makes clickable area boundaries and interactions clearer
- adjusts styling

Before:
![image](https://github.com/dhis2/maintenance-app-beta/assets/33054985/54040ffe-e514-4f3e-8f2c-aa3088965244)

After:
![image](https://github.com/dhis2/maintenance-app-beta/assets/33054985/1939ac93-7ee0-40ee-9443-e506ac23feb0)
