### PR TITLE
fix(edit): fix icons api response

### DIFF
--- a/src/components/ColorAndIconPicker/useIconsQuery.ts
+++ b/src/components/ColorAndIconPicker/useIconsQuery.ts
@@ -1,5 +1,7 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 import { useMemo } from 'react'
+import { PagedResponse } from './../../types/generated/utility'
+import { WrapQueryResponse } from './../../types/query'
 
 export interface Icon {
     description: string
@@ -8,12 +10,10 @@ export interface Icon {
     keywords?: string[]
 }
 
-type IconsResponse = {
-    icons: Array<Icon>
-}
+type IconsResponse = WrapQueryResponse<PagedResponse<Icon, 'icons'>>
 
 const ICONS_QUERY = {
-    icons: {
+    result: {
         resource: 'icons',
     },
 }
@@ -30,8 +30,7 @@ export function useIconsQuery() {
                 outline: [],
             }
         }
-
-        const { icons: unsortedIcons } = data
+        const { icons: unsortedIcons } = data.result
         const sortedIcons = unsortedIcons.sort(
             ({ key: left }, { key: right }) => left.localeCompare(right)
         )

--- a/src/types/generated/utility.ts
+++ b/src/types/generated/utility.ts
@@ -11,12 +11,8 @@ export type ModelCollectionResponse<
 > = PagedResponse<T, PagedListName>
 
 export type PagedResponse<T, PagedListName extends string = 'result'> = {
-    pager: Pager
-} & CollectionPart<T, PagedListName>
-
-type CollectionPart<T, PagedListName extends string = 'result'> = {
     [K in PagedListName]: T[]
-}
+} & { pager: Pager }
 
 type BaseGist<T> = IdentifiableObject & {
     apiEndpoints: GistApiEndpoints<T>

--- a/src/types/generated/utility.ts
+++ b/src/types/generated/utility.ts
@@ -5,22 +5,23 @@ import { IdentifiableObject, GistPager, Pager } from './'
 export type ModelCollection<T = IdentifiableObject> = Array<T>
 type ModelReference = IdentifiableObject | ModelCollection
 
-export type ModelCollectionPart<
-    T extends IdentifiableObject,
-    PagedListName extends string = 'result'
-> = {
-    [K in PagedListName]: T[]
-}
 export type ModelCollectionResponse<
     T extends IdentifiableObject = IdentifiableObject,
     PagedListName extends string = 'result'
-> = {
+> = PagedResponse<T, PagedListName>
+
+export type PagedResponse<T, PagedListName extends string = 'result'> = {
     pager: Pager
-} & ModelCollectionPart<T, PagedListName>
+} & CollectionPart<T, PagedListName>
+
+type CollectionPart<T, PagedListName extends string = 'result'> = {
+    [K in PagedListName]: T[]
+}
 
 type BaseGist<T> = IdentifiableObject & {
     apiEndpoints: GistApiEndpoints<T>
 }
+
 export type GistApiEndpoints<T> = {
     // filter keys that are references and map them to string
     [P in keyof T as T[P] extends ModelReference ? P : never]: string


### PR DESCRIPTION

List API for icons has changed in 2.41. It's now a paginated response. There's currently still issues with the API, so we will have to update the app to support the pagination part later. But this fixes so that the form doesn't crash due to wrong response.

