### PR TITLE
chore(workflow): check types before build

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -24,6 +24,9 @@ jobs:
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
+            - name: Check types
+              run: yarn check-types
+
             - name: Build
               run: yarn d2-app-scripts build
 

--- a/src/pages/DefaultSectionList.tsx
+++ b/src/pages/DefaultSectionList.tsx
@@ -34,7 +34,7 @@ export const DefaultSectionList = () => {
             },
         },
     }
-    const { error, data } = useQuery({
+    const { error, data, refetch } = useQuery({
         queryKey: [query],
         queryFn: ({ queryKey: [query], signal }) => {
             return engine.query(query, { signal }) as Promise<ModelListResponse>
@@ -48,6 +48,7 @@ export const DefaultSectionList = () => {
                 error={error as FetchError | undefined}
                 data={modelList}
                 pager={data?.result.pager}
+                refetch={refetch}
             />
         </div>
     )


### PR DESCRIPTION
Add a check for  running type-checks before building. However, I'm not sure if it's best to

1. Check types in as a step in `build`-job
    * This means we don't build at all if the type-check fails, in my opinion we shouldn't build at all if type-checking fails.
2. Check types as a step in `lint`-job.
    * This means build will still run.  
3. Check types as it's own job
    * Imo the least attractive option for now, as it's adds another runner and needs to install deps etc. Could be useful if we want more complex step to run conditionally whether it's a TS-app or not. 
4. Just add it in `package.json` "build"-script; `"build": "yarn check-types && d2-app-scripts build"`
    * This would mean no changes to workflow, but can be annoying if you eg. want to pass arguments to build. 