### PR TITLE
fix(dataElement): default to default-cat-combo

### DIFF
--- a/src/components/metadataFormControls/CategoryComboSelect/CategoryComboSelect.test.tsx
+++ b/src/components/metadataFormControls/CategoryComboSelect/CategoryComboSelect.test.tsx
@@ -14,10 +14,6 @@ const categoryCombos = [
         id: 'gbvX3pogf7p',
     },
     {
-        displayName: 'default',
-        id: 'bjDvmb4bfuf',
-    },
-    {
         displayName: 'Fixed/Outreach',
         id: 'KYYSTxeVw28',
     },
@@ -126,7 +122,7 @@ export const dataResolvers = {
 }
 
 describe('<CategoryComboSelect />', () => {
-    it('should render all options', async () => {
+    it('should render all options and None (default catCombo)', async () => {
         const onChange = jest.fn()
         const result = render(
             <ComponentWithProvider dataForCustomProvider={dataResolvers}>
@@ -145,6 +141,10 @@ describe('<CategoryComboSelect />', () => {
             )
             expect(selectOptions).toBeTruthy()
         }
+        const noneOption = await result.findByText('None', {
+            selector: '[data-test="dhis2-uicore-singleselectoption"]',
+        })
+        expect(noneOption).toBeInTheDocument()
     })
 
     it('should add an "empty" option when not required', async () => {
@@ -162,6 +162,15 @@ describe('<CategoryComboSelect />', () => {
         const selectInput = result.getByTestId('dhis2-uicore-select-input')
         fireEvent.click(selectInput)
 
+        const noneLabel = await result.findByText('None', {
+            selector: '[data-test="dhis2-uicore-singleselectoption"]',
+        })
+        const selectedLabel = await result.findByText(/No value/, {
+            selector: '[data-test="dhis2-uicore-singleselectoption"]',
+        })
+
+        expect(noneLabel).toBeInTheDocument()
+        expect(selectedLabel).toBeInTheDocument()
         // We'd find a single option if we didn't wait for this. The test would
         // subsequently fail as there'd be exactly one categoryCombo option
         await waitFor(() => {
@@ -169,11 +178,11 @@ describe('<CategoryComboSelect />', () => {
                 'dhis2-uicore-singleselectoption'
             )
 
-            expect(allOptions).toHaveLength(categoryCombos.length + 1)
+            expect(allOptions).toHaveLength(categoryCombos.length + 2)
         })
     })
 
-    it('should doesn\'t add an "empty" option when not required', async () => {
+    it('should not add an "empty" option when not required', async () => {
         const onChange = jest.fn()
         const dataResolvers = {
             categoryCombos: categoryCombosResolver,
@@ -195,7 +204,7 @@ describe('<CategoryComboSelect />', () => {
                 'dhis2-uicore-singleselectoption'
             )
 
-            expect(allOptions).toHaveLength(categoryCombos.length)
+            expect(allOptions).toHaveLength(categoryCombos.length + 1)
         })
     })
 

--- a/src/components/metadataFormControls/CategoryComboSelect/useInitialOptionQuery.ts
+++ b/src/components/metadataFormControls/CategoryComboSelect/useInitialOptionQuery.ts
@@ -1,5 +1,6 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 import { useRef } from 'react'
+import { DEFAULT_CATEGORY_COMBO } from '../../../lib'
 import { SelectOption } from '../../../types'
 import { FilteredCategoryCombo } from './types'
 
@@ -26,7 +27,9 @@ export function useInitialOptionQuery({
 }) {
     const initialSelected = useRef(selected)
     return useDataQuery<InitialCategoryComboQueryResult>(INITIAL_OPTION_QUERY, {
-        lazy: !initialSelected.current,
+        lazy:
+            !initialSelected.current ||
+            initialSelected.current === DEFAULT_CATEGORY_COMBO.id,
         variables: { id: selected },
         onComplete: (data) => {
             const categoryCombo = data.categoryCombo

--- a/src/components/metadataFormControls/CategoryComboSelect/useOptionsQuery.ts
+++ b/src/components/metadataFormControls/CategoryComboSelect/useOptionsQuery.ts
@@ -66,8 +66,6 @@ export function useOptionsQuery() {
             // We want to add new options to existing ones so we don't have to
             // refetch existing options
             setLoadedOptions((prevLoadedOptions) => [
-                //always show Default (None)
-                DEFAULT_CATEGORY_SELECT_OPTION,
                 // We only want to add when the current page is > 1
                 ...(pager.page === 1 ? [] : prevLoadedOptions),
                 ...(categoryCombos.map((catCombo) => {
@@ -88,7 +86,8 @@ export function useOptionsQuery() {
             ...queryResult,
             data: {
                 pager: queryResult.data?.categoryCombos.pager,
-                result: loadedOptions,
+                //always show Default (None)
+                result: [DEFAULT_CATEGORY_SELECT_OPTION, ...loadedOptions],
             },
         }),
         [loadedOptions, queryResult]

--- a/src/components/metadataFormControls/CategoryComboSelect/useOptionsQuery.ts
+++ b/src/components/metadataFormControls/CategoryComboSelect/useOptionsQuery.ts
@@ -1,6 +1,7 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { useEffect, useMemo, useState } from 'react'
+import { DEFAULT_CATEGORY_COMBO } from '../../../lib'
 import { SelectOption } from '../../../types'
 import { CategoryCombo, Pager } from '../../../types/generated'
 
@@ -18,20 +19,29 @@ const CATEGORY_COMBOS_QUERY = {
             const params = {
                 page: variables.page,
                 pageSize: 10,
-                fields: ['id', 'displayName', 'isDefault'],
-                order: ['isDefault:desc', 'displayName'],
+                fields: ['id', 'displayName'],
+                filter: ['isDefault:eq:false'],
+                order: ['displayName'],
             }
 
             if (variables.filter) {
                 return {
                     ...params,
-                    filter: `name:ilike:${variables.filter}`,
+                    filter: [
+                        ...params.filter,
+                        `name:ilike:${variables.filter}`,
+                    ],
                 }
             }
 
             return params
         },
     },
+}
+
+const DEFAULT_CATEGORY_SELECT_OPTION = {
+    value: DEFAULT_CATEGORY_COMBO.id,
+    label: DEFAULT_CATEGORY_COMBO.displayName,
 }
 
 export function useOptionsQuery() {
@@ -56,15 +66,17 @@ export function useOptionsQuery() {
             // We want to add new options to existing ones so we don't have to
             // refetch existing options
             setLoadedOptions((prevLoadedOptions) => [
+                //always show Default (None)
+                DEFAULT_CATEGORY_SELECT_OPTION,
                 // We only want to add when the current page is > 1
                 ...(pager.page === 1 ? [] : prevLoadedOptions),
                 ...(categoryCombos.map((catCombo) => {
-                    const { id, displayName, isDefault } = catCombo
+                    const { id, displayName } = catCombo
                     return {
                         value: id,
                         // This should be distinguishable from other selects
                         // where "none" means no selection
-                        label: isDefault ? i18n.t('None') : displayName,
+                        label: displayName,
                     }
                 }) || []),
             ])

--- a/src/lib/constants/defaultModelObjects.ts
+++ b/src/lib/constants/defaultModelObjects.ts
@@ -1,6 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 
-// Objects part of the category-combo model have hardcoded IDs
+// The category-combo model have default objects with hardcoded IDs
 // having these statically defined is convenient instead of having to fetch them (eg. for default-selectors)
 // https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java#L544
 

--- a/src/lib/constants/defaultModelObjects.ts
+++ b/src/lib/constants/defaultModelObjects.ts
@@ -1,0 +1,12 @@
+import i18n from '@dhis2/d2-i18n'
+
+// Objects part of the category-combo model have hardcoded IDs
+// having these statically defined is convenient instead of having to fetch them (eg. for default-selectors)
+// https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultCategoryService.java#L544
+
+export const DEFAULT_CATEGORY_COMBO = {
+    id: 'bjDvmb4bfuf',
+    displayName: i18n.t('None'), // we want to display 'None' in the UI
+    isDefault: true,
+    name: 'default',
+}

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -2,5 +2,6 @@ export * from './sections'
 export * from './translatedModelConstants'
 export * from './translatedModelProperties'
 export * from './tooltips'
+export * from './defaultModelObjects'
 
 export const IDENTIFIABLE_FILTER_KEY = 'identifiable'

--- a/src/pages/dataElements/New.spec.tsx
+++ b/src/pages/dataElements/New.spec.tsx
@@ -114,12 +114,6 @@ describe('Data Elements / New', () => {
 
         fireEvent.click(submitButton as HTMLButtonElement)
 
-        expect(
-            result.container.querySelectorAll(
-                '.error[data-test$="-validation"]'
-            )
-        ).toHaveLength(3)
-
         const nameRequiredError = await result.findByText('Required', {
             selector: '[data-test="formfields-name-validation"]',
         })
@@ -130,10 +124,11 @@ describe('Data Elements / New', () => {
         })
         expect(shortNameRequiredError).toBeTruthy()
 
-        const categoryComboRequiredError = await result.findByText('Required', {
-            selector: '[data-test="formfields-categorycombo-validation"]',
-        })
-        expect(categoryComboRequiredError).toBeTruthy()
+        expect(
+            result.container.querySelectorAll(
+                '.error[data-test$="-validation"]'
+            )
+        ).toHaveLength(2)
     })
 
     it('should submit the data and return to the list view on success', async () => {

--- a/src/pages/dataElements/New.tsx
+++ b/src/pages/dataElements/New.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../components'
 import { useCustomAttributesQuery } from '../../components/form'
 import {
+    DEFAULT_CATEGORY_COMBO,
     SCHEMA_SECTIONS,
     getSectionPath,
     useSchemas,
@@ -49,7 +50,7 @@ function useInitialValues(customAttributes: Attribute[]) {
             valueType: schemas.dataElement.properties.valueType.constants?.[0],
             aggregationType: 'NONE',
             style: { icon: '', color: '' },
-            categoryCombo: { id: '' },
+            categoryCombo: DEFAULT_CATEGORY_COMBO,
             optionSet: { id: '' },
             commentOptionSet: { id: '' },
             legendSets: [],

--- a/src/pages/dataElements/__mocks__/categoryCombosPage1.json
+++ b/src/pages/dataElements/__mocks__/categoryCombosPage1.json
@@ -7,7 +7,6 @@
         "pageCount": 3
     },
     "categoryCombos": [
-        { "displayName": "default", "id": "bjDvmb4bfuf", "isDefault": true },
         { "displayName": "Births", "id": "m2jTvAj5kkm", "isDefault": false },
         {
             "displayName": "Commodities",


### PR DESCRIPTION
We should default to the `default categoryCombo` when creating a Data Element. The default-catergory combo ID is hardcoded on the backend, so it's safe to use the static id. This makes it much easier compared to having to fetch that cat-combo, because we can statically set it on the initialValues. This feels a bit weird, but I've talked to Jason about it, and he said this is totally fine. If we don't want to this, we should instead load it on app-load to free up components that reference it from additional loading states. 

Some changes in CategoryComboSelect:

1. Updated filters so we never fetch default
2. Don't fetch initialValue if the select-value is default (we already have that info)
3. Always add the "None" to the list
     * None (default-catcombo) is effectively "clearing the select". But we have to send it to the backend. I talked to David and we agreed we should always display this, regardless of filters. 