### PR TITLE
fix: fix cypress tests and color/icon buttons

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -115,7 +115,7 @@ jobs:
               with:
                   token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
 
-             - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v3
               with:
                   node-version: 16
 

--- a/cypress/e2e/dataElements/New.spec.ts
+++ b/cypress/e2e/dataElements/New.spec.ts
@@ -24,12 +24,11 @@ describe('Data elements', () => {
         cy.get('[data-test="formfields-shortname-content"] input').type(
             `shortname ${now}`
         )
+
+        // verify default catcombo is selected
         cy.get(
             '[data-test="formfields-categorycombo"] [data-test="dhis2-uicore-select-input"]'
-        ).click()
-        cy.get(
-            '[data-test="dhis2-uicore-singleselectoption"]:contains("None")'
-        ).click()
+        ).should('contain', 'None')
 
         // Submit form
         cy.get('button:contains("Create data element")').click()
@@ -105,15 +104,7 @@ describe('Data elements', () => {
             '[data-test="dhis2-uicore-singleselectoption"]:contains("Sum")'
         ).click()
 
-        // Select category combo
-        cy.get(
-            '[data-test="formfields-categorycombo"] [data-test="dhis2-uicore-select-input"]'
-        ).click()
-        cy.get(
-            '[data-test="dhis2-uicore-singleselectoption"]:contains("None")'
-        ).click()
-
-        // Select category combo
+        // Select option set
         cy.get(
             '[data-test="formfields-optionset"] [data-test="dhis2-uicore-select-input"]'
         ).click()
@@ -121,7 +112,7 @@ describe('Data elements', () => {
             '[data-test="dhis2-uicore-singleselectoption"]:contains("ARV drugs")'
         ).click()
 
-        // Select category combo
+        // Select comment optionset combo
         cy.get(
             '[data-test="formfields-commentoptionset"] [data-test="dhis2-uicore-select-input"]'
         ).click()
@@ -191,19 +182,16 @@ describe('Data elements', () => {
         // Submit form
         cy.get('button:contains("Create data element")').click()
 
-        // Should have required errors for name, shortname and cat combo
+        // Should have required errors for name, shortname
         cy.get('[data-test$="-validation"]:contains("Required")').should(
             'have.length',
-            3
+            2
         )
         cy.get(
             '[data-test="formfields-name-validation"]:contains("Required")'
         ).should('exist')
         cy.get(
             '[data-test="formfields-shortname-validation"]:contains("Required")'
-        ).should('exist')
-        cy.get(
-            '[data-test="formfields-categorycombo-validation"]:contains("Required")'
         ).should('exist')
     })
 })

--- a/src/components/ColorAndIconPicker/ColorPicker.tsx
+++ b/src/components/ColorAndIconPicker/ColorPicker.tsx
@@ -18,6 +18,7 @@ export function ColorPicker({
     return (
         <>
             <button
+                type="button"
                 ref={ref}
                 onClick={() => setShowPicker(true)}
                 className={cx(classes.container, {

--- a/src/components/ColorAndIconPicker/IconPicker.tsx
+++ b/src/components/ColorAndIconPicker/IconPicker.tsx
@@ -19,6 +19,7 @@ export function IconPicker({
     return (
         <>
             <button
+                type="button"
                 onClick={() => setShowPicker(true)}
                 className={cx(classes.container, {
                     [classes.hasIcon]: !!icon,


### PR DESCRIPTION
Color and Icon buttons were changed to `button` without `type=button`, this means they were submit-buttons and those submitted the form when clicked.