### PR TITLE
fix(manageView): stable initialValues for form

### DIFF
--- a/src/components/sectionList/listView/ManageListView.tsx
+++ b/src/components/sectionList/listView/ManageListView.tsx
@@ -61,11 +61,20 @@ export const ManageListView = ({
     const section = useModelSectionHandleOrThrow()
     const { saveView } = useMutateModelListViews()
 
-    const columnsConfig = getColumnsForSection(section.name)
-    const filtersConfig = getFiltersForSection(section.name)
+    const { defaultColumns, defaultFilters, columnsConfig, filtersConfig } =
+        useMemo(() => {
+            const columnsConfig = getColumnsForSection(section.name)
+            const filtersConfig = getFiltersForSection(section.name)
 
-    const defaultColumns = columnsConfig.default.map(toPath)
-    const defaultFilters = filtersConfig.default.map(toFilterKey)
+            const defaultColumns = columnsConfig.default.map(toPath)
+            const defaultFilters = filtersConfig.default.map(toFilterKey)
+            return {
+                defaultColumns,
+                defaultFilters,
+                columnsConfig,
+                filtersConfig,
+            }
+        }, [section.name])
 
     const handleSave = async (values: FormValues) => {
         const isDefault = (arr: string[], def: string[]) =>


### PR DESCRIPTION
I encountered a bug where the `initialValues` was causing the the selected "columns" and "filters" to reset when you changed between the tabs in "Mange view"-dialog.

This should fix that, and cause the `initialValues` to be stable. 