### PR TITLE
fix(orgUnit): add reference assignment fields

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-10-22T10:31:57.931Z\n"
-"PO-Revision-Date: 2024-10-22T10:31:57.932Z\n"
+"POT-Creation-Date: 2024-10-23T11:07:53.225Z\n"
+"PO-Revision-Date: 2024-10-23T11:07:53.225Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -123,6 +123,21 @@ msgstr "Failed to load {{label}}"
 msgid "Failed to load"
 msgstr "Failed to load"
 
+msgid "Download"
+msgstr "Download"
+
+msgid "Merge"
+msgstr "Merge"
+
+msgid "Delete source data element values"
+msgstr "Delete source data element values"
+
+msgid "Last updated"
+msgstr "Last updated"
+
+msgid "Discard"
+msgstr "Discard"
+
 msgid "Aggregation level(s)"
 msgstr "Aggregation level(s)"
 
@@ -222,9 +237,6 @@ msgstr "Created"
 msgid "Last updated by"
 msgstr "Last updated by"
 
-msgid "Last updated"
-msgstr "Last updated"
-
 msgid "Id"
 msgstr "Id"
 
@@ -245,9 +257,6 @@ msgstr "Details"
 
 msgid "Failed to load details"
 msgstr "Failed to load details"
-
-msgid "Download"
-msgstr "Download"
 
 msgid "Download {{section}}"
 msgstr "Download {{section}}"
@@ -1129,6 +1138,36 @@ msgstr "Latitude"
 
 msgid "Longitude"
 msgstr "Longitude"
+
+msgid "Reference assignments"
+msgstr "Reference assignments"
+
+msgid "Assign the organisation unit to related models."
+msgstr "Assign the organisation unit to related models."
+
+msgid "Available data sets"
+msgstr "Available data sets"
+
+msgid "Selected data sets"
+msgstr "Selected data sets"
+
+msgid "Filter available data sets"
+msgstr "Filter available data sets"
+
+msgid "Filter selected data sets"
+msgstr "Filter selected data sets"
+
+msgid "Available programs"
+msgstr "Available programs"
+
+msgid "Selected programs"
+msgstr "Selected programs"
+
+msgid "Filter available programs"
+msgstr "Filter available programs"
+
+msgid "Filter selected programs"
+msgstr "Filter selected programs"
 
 msgid "New organisation unit will be created inside {{displayName}}"
 msgstr "New organisation unit will be created inside {{displayName}}"

--- a/src/pages/organisationUnits/form/OrganisationUnitFormFields.tsx
+++ b/src/pages/organisationUnits/form/OrganisationUnitFormFields.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { Field as FieldRFF } from 'react-final-form'
 import {
     CustomAttributesSection,
+    ModelTransferField,
     StandardFormField,
     StandardFormSection,
     StandardFormSectionDescription,
@@ -14,13 +15,17 @@ import {
     DescriptionField,
 } from '../../../components/form'
 import { DateField } from '../../../components/form/fields/DateField'
-import { SCHEMA_SECTIONS } from '../../../lib'
+import { SCHEMA_SECTIONS, useSystemSetting } from '../../../lib'
 import { ImageField } from './ImageField'
 import { OrganisationUnitSelector } from './OrganisationUnitSelector'
 
 const schemaSection = SCHEMA_SECTIONS.organisationUnit
 
 export function OrganisationUnitFormField() {
+    const allowReferenceAssignments = useSystemSetting(
+        'keyAllowObjectAssignment'
+    )
+
     return (
         <>
             <StandardFormSection>
@@ -142,6 +147,50 @@ export function OrganisationUnitFormField() {
                     max="180"
                 />
             </StandardFormSection>
+            {allowReferenceAssignments && (
+                <StandardFormSection>
+                    <StandardFormSectionTitle>
+                        {i18n.t('Reference assignment')}
+                    </StandardFormSectionTitle>
+                    <StandardFormSectionDescription>
+                        {i18n.t(
+                            'Assign the organisation unit to related objects.'
+                        )}
+                    </StandardFormSectionDescription>
+                    <StandardFormField>
+                        <ModelTransferField
+                            name="dataSets"
+                            query={{
+                                resource: 'dataSets',
+                            }}
+                            leftHeader={i18n.t('Available data sets')}
+                            rightHeader={i18n.t('Selected data sets')}
+                            filterPlaceholder={i18n.t(
+                                'Filter available data sets'
+                            )}
+                            filterPlaceholderPicked={i18n.t(
+                                'Filter selected data sets'
+                            )}
+                        />
+                    </StandardFormField>
+                    <StandardFormField>
+                        <ModelTransferField
+                            name="programs"
+                            query={{
+                                resource: 'programs',
+                            }}
+                            leftHeader={i18n.t('Available programs')}
+                            rightHeader={i18n.t('Selected programs')}
+                            filterPlaceholder={i18n.t(
+                                'Filter available programs'
+                            )}
+                            filterPlaceholderPicked={i18n.t(
+                                'Filter selected programs'
+                            )}
+                        />
+                    </StandardFormField>
+                </StandardFormSection>
+            )}
 
             <CustomAttributesSection />
         </>

--- a/src/pages/organisationUnits/form/organisationUnitSchema.ts
+++ b/src/pages/organisationUnits/form/organisationUnitSchema.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod'
 import { getDefaults, modelFormSchemas } from '../../../lib'
 
-const { withAttributeValues, identifiable } = modelFormSchemas
+const { withAttributeValues, identifiable, referenceCollection } =
+    modelFormSchemas
 
 export const organisationUnitSchema = identifiable
     .merge(withAttributeValues)
@@ -24,6 +25,8 @@ export const organisationUnitSchema = identifiable
                 latitude: z.string().optional(),
             })
             .optional(),
+        programs: referenceCollection.optional().default([]),
+        dataSets: referenceCollection.optional().default([]),
     })
 
 export const initialValues = getDefaults(


### PR DESCRIPTION
Adds the fields `programs` and `dataSets`. Which allows the user to add the orgUnit to these related objects. This should only be available when the system setting `keyAllowObjectAssignment` is true. This can be enabled in `System settings`-app, under section `Access` - and enable the field `Allow assigning object to related objects during add or update`. 