### PR TITLE
fix(list): use translated values for name and shortName

### DIFF
--- a/src/components/sectionList/filters/filterSelectors/Filters.module.css
+++ b/src/components/sectionList/filters/filterSelectors/Filters.module.css
@@ -12,7 +12,7 @@
 }
 
 .identifiableSelectionFilter {
-    width: 320px;
+    width: 320px !important;
 }
 
 .filterWrapper {

--- a/src/components/sectionList/listView/ManageListView.tsx
+++ b/src/components/sectionList/listView/ManageListView.tsx
@@ -75,6 +75,7 @@ export const ManageListView = ({
                 filtersConfig,
             }
         }, [section.name])
+    const hasAvailableFilters = filtersConfig.available.length > 0
 
     const handleSave = async (values: FormValues) => {
         const isDefault = (arr: string[], def: string[]) =>
@@ -139,12 +140,16 @@ export const ManageListView = ({
                         >
                             {i18n.t('Columns')}
                         </Tab>
-                        <Tab
-                            selected={selectedTab === 'filters'}
-                            onClick={(_, e) => handleChangeTab('filters', e)}
-                        >
-                            {i18n.t('Filters')}
-                        </Tab>
+                        {hasAvailableFilters && (
+                            <Tab
+                                selected={selectedTab === 'filters'}
+                                onClick={(_, e) =>
+                                    handleChangeTab('filters', e)
+                                }
+                            >
+                                {i18n.t('Filters')}
+                            </Tab>
+                        )}
                     </TabBar>
 
                     <TabContent show={selectedTab === 'columns'}>
@@ -154,12 +159,12 @@ export const ManageListView = ({
                             selectedLabel={i18n.t('Selected columns')}
                             loading={query.isLoading}
                             defaultOptions={defaultColumns}
-                            availableOptions={columnsConfig.available.map(
-                                (c) => ({
+                            availableOptions={columnsConfig.available
+                                .map((c) => ({
                                     label: c.label,
                                     value: c.path,
-                                })
-                            )}
+                                }))
+                                .sort((a, b) => a.label.localeCompare(b.label))}
                         />
                     </TabContent>
                     <TabContent show={selectedTab === 'filters'}>
@@ -169,12 +174,12 @@ export const ManageListView = ({
                             selectedLabel={i18n.t('Selected filters')}
                             loading={query.isLoading}
                             defaultOptions={defaultFilters}
-                            availableOptions={filtersConfig.available.map(
-                                (f) => ({
+                            availableOptions={filtersConfig.available
+                                .map((f) => ({
                                     label: f.label,
                                     value: f.filterKey,
-                                })
-                            )}
+                                }))
+                                .sort((a, b) => a.label.localeCompare(b.label))}
                         />
                     </TabContent>
                     {submitError && (

--- a/src/lib/constants/translatedModelProperties.ts
+++ b/src/lib/constants/translatedModelProperties.ts
@@ -2,6 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 
 const TRANSLATED_PROPERTY: Record<string, string> = {
     aggregationType: i18n.t('Aggregation type'),
+    category: i18n.t('Category'),
     categoryCombo: i18n.t('Category combination'),
     categoryOption: i18n.t('Category option'),
     code: i18n.t('Code'),
@@ -11,6 +12,7 @@ const TRANSLATED_PROPERTY: Record<string, string> = {
     formName: i18n.t('Form name'),
     href: i18n.t('API URL'),
     id: i18n.t('Id'),
+    indicatorType: i18n.t('Indicator type'),
     lastUpdatedBy: i18n.t('Last updated by'),
     created: i18n.t('Created'),
     domainType: i18n.t('Domain type'),

--- a/src/lib/sectionList/listViews/sectionListViewsConfig.ts
+++ b/src/lib/sectionList/listViews/sectionListViewsConfig.ts
@@ -46,13 +46,17 @@ const DESCRIPTORS = {
         label: i18n.t('Public access'),
         filterKey: 'publicAccess',
     },
+    name: {
+        path: 'displayName',
+        label: i18n.t('Name'),
+    },
 } satisfies Record<string, Descriptor>
 
 // This is the default views, and can be overriden per section in modelListViewsConfig below
 export const defaultModelViewConfig = {
     columns: {
         available: [
-            'name',
+            DESCRIPTORS.name,
             'shortName',
             'code',
             'created',
@@ -60,9 +64,10 @@ export const defaultModelViewConfig = {
             'href',
             'id',
             'lastUpdatedBy',
+            'lastUpdated',
             DESCRIPTORS.publicAccess,
         ],
-        default: ['name', DESCRIPTORS.publicAccess, 'lastUpdated'],
+        default: [DESCRIPTORS.name, DESCRIPTORS.publicAccess, 'lastUpdated'],
     },
     filters: {
         available: [DESCRIPTORS.publicAccess],
@@ -85,7 +90,7 @@ export const modelListViewsConfig = {
         columns: {
             available: ['zeroIsSignificant'],
             default: [
-                'name',
+                DESCRIPTORS.name,
                 { label: i18n.t('Domain type'), path: 'domainType' },
                 { label: i18n.t('Value type'), path: 'valueType' },
                 'categoryCombo',
@@ -101,7 +106,7 @@ export const modelListViewsConfig = {
     dataSet: {
         columns: {
             default: [
-                'name',
+                DESCRIPTORS.name,
                 { label: i18n.t('Form type'), path: 'formType' },
                 { label: i18n.t('Period type'), path: 'periodType' },
                 'lastUpdated',
@@ -115,7 +120,7 @@ export const modelListViewsConfig = {
     organisationUnit: {
         columns: {
             available: [],
-            default: ['name', 'id', 'code', 'lastUpdated'],
+            default: [DESCRIPTORS.name, 'id', 'code', 'lastUpdated'],
         },
         filters: {
             default: [],
@@ -124,7 +129,7 @@ export const modelListViewsConfig = {
     categoryOption: {
         columns: {
             available: [
-                'name',
+                DESCRIPTORS.name,
                 'code',
                 'created',
                 'createdBy',
@@ -132,7 +137,11 @@ export const modelListViewsConfig = {
                 'id',
                 DESCRIPTORS.publicAccess,
             ],
-            default: ['name', DESCRIPTORS.publicAccess, 'lastUpdated'],
+            default: [
+                DESCRIPTORS.name,
+                DESCRIPTORS.publicAccess,
+                'lastUpdated',
+            ],
             overrideDefaultAvailable: true,
         },
         filters: {
@@ -142,7 +151,7 @@ export const modelListViewsConfig = {
     category: {
         columns: {
             default: [
-                'name',
+                DESCRIPTORS.name,
                 'dataDimensionType',
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
@@ -155,7 +164,7 @@ export const modelListViewsConfig = {
     indicator: {
         columns: {
             default: [
-                'name',
+                DESCRIPTORS.name,
                 { label: i18n.t('Indicator Type'), path: 'indicatorType' },
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
@@ -165,30 +174,10 @@ export const modelListViewsConfig = {
             default: ['indicatorType'],
         },
     },
-    indicatorType: {
-        columns: {
-            default: [
-                'name',
-                { label: i18n.t('Factor'), path: 'factor' },
-                'lastUpdated',
-            ],
-            available: [
-                'code',
-                'created',
-                'createdBy',
-                'href',
-                'id',
-                'lastUpdatedBy',
-            ],
-        },
-        filters: {
-            default: [],
-        },
-    },
     categoryOptionGroupSet: {
         columns: {
             default: [
-                'name',
+                DESCRIPTORS.name,
                 'dataDimensionType',
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
@@ -201,7 +190,7 @@ export const modelListViewsConfig = {
     categoryOptionGroup: {
         columns: {
             default: [
-                'name',
+                DESCRIPTORS.name,
                 'dataDimensionType',
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
@@ -214,7 +203,7 @@ export const modelListViewsConfig = {
     categoryCombo: {
         columns: {
             default: [
-                'name',
+                DESCRIPTORS.name,
                 'dataDimensionType',
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
@@ -227,7 +216,7 @@ export const modelListViewsConfig = {
     },
     categoryOptionCombo: {
         columns: {
-            default: ['name', 'code', 'lastUpdated'],
+            default: [DESCRIPTORS.name, 'code', 'lastUpdated'],
             available: ['categoryCombo', 'ignoreApproval'],
             // categoryOptionCombo does not have publicAccess
             overrideDefaultAvailable: true,

--- a/src/lib/sectionList/listViews/sectionListViewsConfig.ts
+++ b/src/lib/sectionList/listViews/sectionListViewsConfig.ts
@@ -174,6 +174,26 @@ export const modelListViewsConfig = {
             default: ['indicatorType'],
         },
     },
+    indicatorType: {
+        columns: {
+            default: [
+                'name',
+                { label: i18n.t('Factor'), path: 'factor' },
+                'lastUpdated',
+            ],
+            available: [
+                'code',
+                'created',
+                'createdBy',
+                'href',
+                'id',
+                'lastUpdatedBy',
+            ],
+        },
+        filters: {
+            default: [],
+        },
+    },
     categoryOptionGroupSet: {
         columns: {
             default: [

--- a/src/lib/sectionList/listViews/sectionListViewsConfig.ts
+++ b/src/lib/sectionList/listViews/sectionListViewsConfig.ts
@@ -50,6 +50,10 @@ const DESCRIPTORS = {
         path: 'displayName',
         label: i18n.t('Name'),
     },
+    shortName: {
+        path: 'displayShortName',
+        label: i18n.t('Short name'),
+    },
 } satisfies Record<string, Descriptor>
 
 // This is the default views, and can be overriden per section in modelListViewsConfig below
@@ -57,7 +61,6 @@ export const defaultModelViewConfig = {
     columns: {
         available: [
             DESCRIPTORS.name,
-            'shortName',
             'code',
             'created',
             'createdBy',
@@ -78,6 +81,11 @@ export const defaultModelViewConfig = {
     },
 } satisfies ViewConfig
 
+const defaultAvailableColumnsNoSharing =
+    defaultModelViewConfig.columns.available.filter(
+        (col) => col !== DESCRIPTORS.publicAccess
+    )
+
 /* this is the default views (eg. which columns and filters) to show in the List-page for each section
 	Note: by default, the available columns are merged with columnsDefault.available above.
 	If it's needed to override this for a section, set overrideDefaultAvailable to true
@@ -88,7 +96,7 @@ export const defaultModelViewConfig = {
 export const modelListViewsConfig = {
     dataElement: {
         columns: {
-            available: ['zeroIsSignificant'],
+            available: [DESCRIPTORS.shortName, 'zeroIsSignificant'],
             default: [
                 DESCRIPTORS.name,
                 { label: i18n.t('Domain type'), path: 'domainType' },
@@ -103,6 +111,18 @@ export const modelListViewsConfig = {
             default: ['domainType', 'valueType', 'dataSet', 'categoryCombo'],
         },
     },
+    dataElementGroup: {
+        columns: {
+            available: [DESCRIPTORS.shortName],
+        },
+        filters: {},
+    },
+    dataElementGroupSet: {
+        columns: {
+            available: [DESCRIPTORS.shortName],
+        },
+        filters: {},
+    },
     dataSet: {
         columns: {
             default: [
@@ -112,6 +132,7 @@ export const modelListViewsConfig = {
                 'lastUpdated',
                 DESCRIPTORS.publicAccess,
             ],
+            available: [DESCRIPTORS.shortName],
         },
         filters: {
             default: ['formType'],
@@ -119,7 +140,7 @@ export const modelListViewsConfig = {
     },
     organisationUnit: {
         columns: {
-            available: [],
+            available: [DESCRIPTORS.shortName],
             default: [DESCRIPTORS.name, 'id', 'code', 'lastUpdated'],
         },
         filters: {
@@ -130,6 +151,7 @@ export const modelListViewsConfig = {
         columns: {
             available: [
                 DESCRIPTORS.name,
+                DESCRIPTORS.shortName,
                 'code',
                 'created',
                 'createdBy',
@@ -156,6 +178,7 @@ export const modelListViewsConfig = {
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
             ],
+            available: [DESCRIPTORS.shortName],
         },
         filters: {
             default: ['dataDimensionType', 'categoryCombo'],
@@ -165,10 +188,11 @@ export const modelListViewsConfig = {
         columns: {
             default: [
                 DESCRIPTORS.name,
-                { label: i18n.t('Indicator Type'), path: 'indicatorType' },
+                'indicatorType',
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
             ],
+            available: [DESCRIPTORS.shortName],
         },
         filters: {
             default: ['indicatorType'],
@@ -177,21 +201,17 @@ export const modelListViewsConfig = {
     indicatorType: {
         columns: {
             default: [
-                'name',
+                DESCRIPTORS.name,
                 { label: i18n.t('Factor'), path: 'factor' },
                 'lastUpdated',
             ],
-            available: [
-                'code',
-                'created',
-                'createdBy',
-                'href',
-                'id',
-                'lastUpdatedBy',
-            ],
+            available: defaultAvailableColumnsNoSharing,
+            overrideDefaultAvailable: true,
         },
         filters: {
             default: [],
+            available: [],
+            overrideDefaultAvailable: true,
         },
     },
     categoryOptionGroupSet: {
@@ -202,6 +222,7 @@ export const modelListViewsConfig = {
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
             ],
+            available: [DESCRIPTORS.shortName],
         },
         filters: {
             default: ['dataDimensionType'],
@@ -215,6 +236,7 @@ export const modelListViewsConfig = {
                 DESCRIPTORS.publicAccess,
                 'lastUpdated',
             ],
+            available: [DESCRIPTORS.shortName],
         },
         filters: {
             default: ['dataDimensionType'],
@@ -237,7 +259,7 @@ export const modelListViewsConfig = {
     categoryOptionCombo: {
         columns: {
             default: [DESCRIPTORS.name, 'code', 'lastUpdated'],
-            available: ['categoryCombo', 'ignoreApproval'],
+            available: defaultAvailableColumnsNoSharing,
             // categoryOptionCombo does not have publicAccess
             overrideDefaultAvailable: true,
         },

--- a/src/pages/dataElements/List.spec.tsx
+++ b/src/pages/dataElements/List.spec.tsx
@@ -172,7 +172,7 @@ describe('Data Elements List', () => {
                         dataElements: [
                             {
                                 ...FIRST_FILTERED_DATA_ELEMENT,
-                                name: 'first page result',
+                                displayName: 'first page result',
                             },
                         ],
                     }
@@ -186,7 +186,7 @@ describe('Data Elements List', () => {
                         dataElements: [
                             {
                                 ...FIRST_FILTERED_DATA_ELEMENT,
-                                name: 'second page result',
+                                displayName: 'second page result',
                             },
                         ],
                     }
@@ -218,7 +218,7 @@ describe('Data Elements List', () => {
             ).toHaveAttribute('disabled')
         })
         // next page
-        it('should allowing going to Next page', async () => {
+        it('should allow going to Next page', async () => {
             const user = userEvent.setup()
             const { getByTestId, findByText, queryByText } =
                 await renderWithPager()
@@ -270,7 +270,7 @@ describe('Data Elements List', () => {
                     result: [
                         {
                             ...FIRST_FILTERED_DATA_ELEMENT,
-                            name: 'last page result',
+                            displayName: 'last page result',
                         },
                     ],
                 },

--- a/src/pages/dataElements/__mocks__/list/dataElementsMock.json
+++ b/src/pages/dataElements/__mocks__/list/dataElementsMock.json
@@ -9,6 +9,7 @@
     "dataElements": [
         {
             "name": "ANC 1st visit",
+            "displayName": "ANC 1st visit",
             "lastUpdated": "2017-03-02T16:52:07.101",
             "sharing": {
                 "public": "r-------"
@@ -31,6 +32,7 @@
         },
         {
             "name": "ANC 2nd visit",
+            "displayName": "ANC 2nd visit",
             "lastUpdated": "2024-03-05T22:55:32.803",
             "sharing": {
                 "public": "r-------"
@@ -53,6 +55,7 @@
         },
         {
             "name": "ANC 3rd visit",
+            "displayName": "ANC 3rd visit",
             "lastUpdated": "2024-03-05T23:09:47.216",
             "sharing": {
                 "public": "r-------"
@@ -75,6 +78,7 @@
         },
         {
             "name": "ANC 4th or more visits",
+            "displayName": "ANC 4th or more visits",
             "lastUpdated": "2024-03-05T09:48:09.192",
             "sharing": {
                 "public": "rw------"
@@ -97,6 +101,7 @@
         },
         {
             "name": "ARI treated with antibiotics (pneumonia) follow-up",
+            "displayName": "ARI treated with antibiotics (pneumonia) follow-up",
             "lastUpdated": "2024-03-05T23:10:04.850",
             "sharing": {
                 "public": "rw------"
@@ -119,6 +124,7 @@
         },
         {
             "name": "ARI treated with antibiotics (pneumonia) new",
+            "displayName": "ARI treated with antibiotics (pneumonia) new",
             "lastUpdated": "2024-03-05T22:52:47.886",
             "sharing": {
                 "public": "r-------"
@@ -141,6 +147,7 @@
         },
         {
             "name": "ARI treated with antibiotics (pneumonia) referrals",
+            "displayName": "ARI treated with antibiotics (pneumonia) referrals",
             "lastUpdated": "2024-03-05T09:48:09.193",
             "sharing": {
                 "public": "rw------"
@@ -163,6 +170,7 @@
         },
         {
             "name": "ARI treated without antibiotics (cough) follow-up",
+            "displayName": "ARI treated without antibiotics (cough) follow-up",
             "lastUpdated": "2024-03-05T09:48:09.191",
             "sharing": {
                 "public": "rw------"
@@ -185,6 +193,7 @@
         },
         {
             "name": "ARI treated without antibiotics (cough) new",
+            "displayName": "ARI treated without antibiotics (cough) new",
             "lastUpdated": "2024-03-05T09:48:09.194",
             "sharing": {
                 "public": "rw------"
@@ -207,6 +216,7 @@
         },
         {
             "name": "ARI treated without antibiotics (cough) referrals",
+            "displayName": "ARI treated without antibiotics (cough) referrals",
             "lastUpdated": "2024-03-05T09:48:09.191",
             "sharing": {
                 "public": "rw------"
@@ -229,6 +239,7 @@
         },
         {
             "name": "ART No clients who stopped TRT due to TRT failure",
+            "displayName": "ART No clients who stopped TRT due to TRT failure",
             "lastUpdated": "2024-03-05T09:48:09.194",
             "sharing": {
                 "public": "rw------"
@@ -251,6 +262,7 @@
         },
         {
             "name": "ART No clients who stopped TRT due to adverse clinical status/event",
+            "displayName": "ART No clients who stopped TRT due to adverse clinical status/event",
             "lastUpdated": "2024-03-05T09:48:09.191",
             "sharing": {
                 "public": "rw------"
@@ -273,6 +285,7 @@
         },
         {
             "name": "ART No clients with change of regimen due to drug toxicity",
+            "displayName": "ART No clients with change of regimen due to drug toxicity",
             "lastUpdated": "2024-03-05T09:48:09.195",
             "sharing": {
                 "public": "rw------"
@@ -295,6 +308,7 @@
         },
         {
             "name": "ART No clients with new adverse drug reaction",
+            "displayName": "ART No clients with new adverse drug reaction",
             "lastUpdated": "2024-03-05T09:48:09.191",
             "sharing": {
                 "public": "rw------"
@@ -317,6 +331,7 @@
         },
         {
             "name": "ART No started Opportunist Infection prophylaxis",
+            "displayName": "ART No started Opportunist Infection prophylaxis",
             "lastUpdated": "2024-03-05T09:48:09.191",
             "sharing": {
                 "public": "rw------"
@@ -339,6 +354,7 @@
         },
         {
             "name": "ART clients with new adverse clinical event",
+            "displayName": "ART clients with new adverse clinical event",
             "lastUpdated": "2024-03-05T09:48:09.192",
             "sharing": {
                 "public": "rw------"
@@ -361,6 +377,7 @@
         },
         {
             "name": "ART defaulters",
+            "displayName": "ART defaulters",
             "lastUpdated": "2024-03-05T09:48:09.192",
             "sharing": {
                 "public": "rw------"
@@ -383,6 +400,7 @@
         },
         {
             "name": "ART enrollment stage 1",
+            "displayName": "ART enrollment stage 1",
             "lastUpdated": "2024-03-05T09:48:09.194",
             "sharing": {
                 "public": "rw------"
@@ -405,6 +423,7 @@
         },
         {
             "name": "ART enrollment stage 2",
+            "displayName": "ART enrollment stage 2",
             "lastUpdated": "2024-03-05T09:48:09.190",
             "sharing": {
                 "public": "rw------"
@@ -427,6 +446,7 @@
         },
         {
             "name": "ART enrollment stage 3",
+            "displayName": "ART enrollment stage 3",
             "lastUpdated": "2024-03-05T09:48:09.193",
             "sharing": {
                 "public": "rw------"

--- a/src/pages/dataElements/__mocks__/list/filteredDataElementsMock.json
+++ b/src/pages/dataElements/__mocks__/list/filteredDataElementsMock.json
@@ -17,6 +17,7 @@
             },
             "id": "JuTpJ2Ywq5b",
             "name": "FILTERED Age of LLINs",
+            "displayName": "FILTERED Age of LLINs",
             "domainType": "TRACKER",
             "valueType": "INTEGER_ZERO_OR_POSITIVE",
             "lastUpdated": "2019-08-21T13:08:02.032",


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-18420 . Also includes some various cleanup of list descriptors, and manage list view.

* Fixes`IdentifiableFilter`-width after UI-upgrade.
* Also adds `lastUpdated` as part of the default available columns. 
* Use translated values for name and shortName
* Remove shortName from default columns
   * This is not present on most objects, so Ive added this to objects that have it.
* Manage view dialog: hide "Filter"-tab if no available filters are present
* Manage view dialog: sort available columns/filters alphabetically. 
* Adds some missing translations for properties. 