### PR TITLE
fix(optionSetSelect): fix optionSet crashing with initialValue

### DIFF
--- a/src/components/metadataFormControls/OptionSetSelect/useInitialOptionQuery.ts
+++ b/src/components/metadataFormControls/OptionSetSelect/useInitialOptionQuery.ts
@@ -4,7 +4,7 @@ import { SelectOption } from '../../../types'
 import { FilteredOptionSet } from './types'
 
 type InitialOptionSetQueryResult = {
-    optionSet: FilteredOptionSet
+    optionSets: FilteredOptionSet
 }
 
 const fields = ['id', 'displayName']
@@ -21,7 +21,7 @@ export function useInitialOptionQuery({
         lazy: !initialSelected.current,
         variables: { id: selected, fields },
         onComplete: (data: InitialOptionSetQueryResult) => {
-            const optionSet = data.optionSet
+            const optionSet = data.optionSets
             const { id: value, displayName: label } = optionSet
             onComplete({ value, label })
         },


### PR DESCRIPTION

## Background

When going to edit a dataElement with an `optionSet` selected, an error would be thrown due to the `UseInitialOptionSet` using the singular name of `optionSet` on the data from `useOptionSetQuery`. 


