### PR TITLE
fix(list): disable list buttons when no access

### DIFF
--- a/src/components/LinkButton/LinkButton.module.css
+++ b/src/components/LinkButton/LinkButton.module.css
@@ -61,7 +61,9 @@
     background-color: #f9fafb;
 }
 
-.linkButton.disabled {
+.linkButton.disabled,
+.linkButton.disabled:active,
+.linkButton.disabled:focus {
     border-color: var(--colors-grey400);
     background-color: #f9fafb;
     box-shadow: none;
@@ -112,7 +114,9 @@
     outline-offset: -5px;
 }
 
-.primary.disabled {
+.primary.disabled,
+.primary.disabled:active,
+.primary.disabled:focus {
     border-color: #93a6bd;
     background: #b3c6de;
     box-shadow: none;
@@ -140,7 +144,9 @@
     background-color: transparent;
 }
 
-.secondary.disabled {
+.secondary.disabled,
+.secondary.disabled:active,
+.secondary.disabled:focus {
     border-color: rgba(74, 87, 104, 0.25);
     background-color: transparent;
     box-shadow: none;
@@ -175,7 +181,9 @@
     background-color: #b72229;
 }
 
-.destructive.disabled {
+.destructive.disabled,
+.destructive.disabled:active,
+.destructive.disabled:focus {
     border-color: #c59898;
     background: #d6a8a8;
     box-shadow: none;
@@ -205,7 +213,9 @@
     box-shadow: none;
 }
 
-.destructive.secondary.disabled {
+.destructive.secondary.disabled,
+.destructive.secondary.disabled:active,
+.destructive.secondary.disabled:focus {
     background: transparent;
     border-color: rgba(74, 87, 104, 0.25);
     color: rgba(183, 28, 28, 0.6);

--- a/src/components/sectionList/listActions/DefaultListActions.tsx
+++ b/src/components/sectionList/listActions/DefaultListActions.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { BaseListModel, useSchemaFromHandle } from '../../../lib'
+import { BaseListModel, TOOLTIPS, useSchemaFromHandle } from '../../../lib'
 import { canEditModel, canDeleteModel } from '../../../lib/models/access'
+import { TooltipWrapper } from '../../tooltip'
 import { ListActions, ActionEdit, ActionMore } from './SectionListActions'
 
 type DefaultListActionProps = {
@@ -26,7 +27,12 @@ export const DefaultListActions = ({
 
     return (
         <ListActions>
-            <ActionEdit modelId={model.id} />
+            <TooltipWrapper
+                condition={!editable}
+                content={TOOLTIPS.noEditAccess}
+            >
+                <ActionEdit disabled={!editable} modelId={model.id} />
+            </TooltipWrapper>
             <ActionMore
                 deletable={deletable}
                 editable={editable}

--- a/src/components/sectionList/listActions/SectionListActions.tsx
+++ b/src/components/sectionList/listActions/SectionListActions.tsx
@@ -27,11 +27,18 @@ export const ListActions = ({ children }: React.PropsWithChildren) => {
     )
 }
 
-export const ActionEdit = ({ modelId }: { modelId: string }) => {
+export const ActionEdit = ({
+    modelId,
+    disabled,
+}: {
+    modelId: string
+    disabled?: boolean
+}) => {
     const preservedSearchState = useLocationSearchState()
     return (
         <LinkButton
             small
+            disabled={disabled}
             secondary
             to={{ pathname: modelId }}
             state={preservedSearchState}
@@ -110,6 +117,7 @@ export const ActionMore = ({
                         >
                             <MenuItem
                                 dense
+                                disabled={!editable}
                                 label={i18n.t('Edit')}
                                 icon={<IconEdit16 />}
                                 onClick={(_, e) => {


### PR DESCRIPTION

## Background

I noticed that some of the `Edit` button was not disabled when the user does not have access to edit the element. 


## Implementation

-  Adds Tooltipwrapper and disabled to Edit button i Actions as well as in "More"-dropdown.
- Adds TooltipWrapper and Disabled to Edit button in DetailsPanel
- Updated `DetailsPanel` to use `LinkButton` instead of a Button wrapped in Link - which is not really valid HTML.
- Fix css `disabled` styling of `LinkButton`, keeping the same style even if `active` or `hover`. 