### PR TITLE
fix(categoryOptionGroups): add custom attributesection to group/groupset

### DIFF
--- a/src/pages/categoryOptionGroupSets/form/CategoryOptionGroupSetFormFields.tsx
+++ b/src/pages/categoryOptionGroupSets/form/CategoryOptionGroupSetFormFields.tsx
@@ -3,6 +3,7 @@ import { RadioFieldFF, CheckboxFieldFF } from '@dhis2/ui'
 import React from 'react'
 import { Field } from 'react-final-form'
 import {
+    CustomAttributesSection,
     DefaultIdentifiableFields,
     DescriptionField,
     HorizontalFieldGroup,
@@ -112,6 +113,7 @@ function CategoryOptionGroupSetFormFields() {
                     </StandardFormField>
                 </StandardFormField>
             </StandardFormSection>
+            <CustomAttributesSection schemaSection={section} />
         </>
     )
 }

--- a/src/pages/categoryOptionGroups/form/CategoryOptionGroupFormFields.tsx
+++ b/src/pages/categoryOptionGroups/form/CategoryOptionGroupFormFields.tsx
@@ -3,6 +3,7 @@ import { RadioFieldFF, CheckboxFieldFF } from '@dhis2/ui'
 import React from 'react'
 import { Field } from 'react-final-form'
 import {
+    CustomAttributesSection,
     DefaultIdentifiableFields,
     DescriptionField,
     HorizontalFieldGroup,
@@ -110,6 +111,7 @@ function CategoryOptionGroupFormFields() {
                         />
                     </StandardFormField>
                 </StandardFormField>
+                <CustomAttributesSection schemaSection={section} />
             </StandardFormSection>
         </>
     )


### PR DESCRIPTION
Attributes-section was missing for `categoryOptionGroups` and `categoryOptionGroupSet`.