### PR TITLE
fix: save navigation for dataElementGroup and -Sets

### DIFF
--- a/src/pages/dataElementGroupSets/Edit.tsx
+++ b/src/pages/dataElementGroupSets/Edit.tsx
@@ -34,6 +34,7 @@ type DataElementGroupSetQueryResponse = {
 }
 
 const section = SCHEMA_SECTIONS.dataElementGroupSet
+const listPath = `/${getSectionPath(section)}`
 
 const query = {
     dataElementGroupSet: {
@@ -138,7 +139,7 @@ function DataElementGroupSetForm({
             return errors
         }
 
-        navigate(getSectionPath(section))
+        navigate(listPath)
     }
 
     return (

--- a/src/pages/dataElementGroups/Edit.tsx
+++ b/src/pages/dataElementGroups/Edit.tsx
@@ -32,6 +32,8 @@ type DataElementGroupQueryResponse = {
 
 const section = SCHEMA_SECTIONS.dataElementGroup
 
+const listPath = `/${getSectionPath(section)}`
+
 const query = {
     dataElementGroup: {
         resource: `dataElementGroups`,
@@ -127,7 +129,7 @@ function DataElementGroupForm({
             return errors
         }
 
-        navigate(getSectionPath(section))
+        navigate(listPath)
     }
 
     return (


### PR DESCRIPTION
I noticed that when editing and saving `dataElementGroup` and `dataElementGroupSet` the navigation would be relative, and result in an error after saving because the page does not exist.

I'm unsure how and when this was introduced, because I'm pretty confident that this hasn't always been the case. 