### PR TITLE
fix(validation): use dynamic schema validator for common fields

### DIFF
--- a/src/components/form/fields/DescriptionField.tsx
+++ b/src/components/form/fields/DescriptionField.tsx
@@ -1,9 +1,10 @@
 import i18n from '@dhis2/d2-i18n'
-import { TextAreaFieldFF } from '@dhis2/ui'
+import { createMaxCharacterLength, TextAreaFieldFF } from '@dhis2/ui'
 import React from 'react'
 import { Field as FieldRFF } from 'react-final-form'
 import { SchemaSection } from '../../../lib'
-import { useValidator } from '../../../lib/models/useFieldValidators'
+
+const validateMaxLength = createMaxCharacterLength(2000)
 
 export function DescriptionField({
     helpText,
@@ -12,8 +13,6 @@ export function DescriptionField({
     helpText?: string
     schemaSection: SchemaSection
 }) {
-    const validate = useValidator({ schemaSection, property: 'description' })
-
     return (
         <FieldRFF
             component={TextAreaFieldFF}
@@ -22,7 +21,7 @@ export function DescriptionField({
             name="description"
             label={i18n.t('Description')}
             helpText={helpText}
-            validate={validate}
+            validate={validateMaxLength}
             validateFields={[]}
         />
     )

--- a/src/components/form/fields/DescriptionField.tsx
+++ b/src/components/form/fields/DescriptionField.tsx
@@ -1,8 +1,9 @@
 import i18n from '@dhis2/d2-i18n'
-import { createMaxCharacterLength, TextAreaFieldFF } from '@dhis2/ui'
+import { TextAreaFieldFF } from '@dhis2/ui'
 import React from 'react'
 import { Field as FieldRFF } from 'react-final-form'
-import { SchemaSection, useCheckMaxLengthFromSchema } from '../../../lib'
+import { SchemaSection } from '../../../lib'
+import { useValidator } from '../../../lib/models/useFieldValidators'
 
 export function DescriptionField({
     helpText,
@@ -11,7 +12,7 @@ export function DescriptionField({
     helpText?: string
     schemaSection: SchemaSection
 }) {
-    const validate = createMaxCharacterLength(2000)
+    const validate = useValidator({ schemaSection, property: 'description' })
 
     return (
         <FieldRFF

--- a/src/components/form/fields/NameField.tsx
+++ b/src/components/form/fields/NameField.tsx
@@ -1,40 +1,9 @@
 import i18n from '@dhis2/d2-i18n'
 import { InputFieldFF } from '@dhis2/ui'
-import React, { useMemo } from 'react'
+import React from 'react'
 import { Field as FieldRFF, useField } from 'react-final-form'
-import { useParams } from 'react-router-dom'
-import {
-    composeAsyncValidators,
-    required,
-    useCheckMaxLengthFromSchema,
-    useIsFieldValueUnique,
-    SchemaSection,
-} from '../../../lib'
-
-function useValidator({ schemaSection }: { schemaSection: SchemaSection }) {
-    const params = useParams()
-    const modelId = params.id as string
-    const checkIsValueTaken = useIsFieldValueUnique({
-        model: schemaSection.namePlural,
-        field: 'name',
-        id: modelId,
-    })
-
-    const checkMaxLength = useCheckMaxLengthFromSchema(
-        schemaSection.name,
-        'name'
-    )
-
-    return useMemo(
-        () =>
-            composeAsyncValidators<string>([
-                checkIsValueTaken,
-                checkMaxLength,
-                required,
-            ]),
-        [checkIsValueTaken, checkMaxLength]
-    )
-}
+import { SchemaSection } from '../../../lib'
+import { useValidator } from '../../../lib/models/useFieldValidators'
 
 export function NameField({
     schemaSection,
@@ -43,7 +12,7 @@ export function NameField({
     helpText?: string
     schemaSection: SchemaSection
 }) {
-    const validator = useValidator({ schemaSection })
+    const validator = useValidator({ schemaSection, property: 'name' })
     const { meta } = useField('name', {
         subscription: { validating: true },
     })

--- a/src/components/form/fields/ShortNameField.tsx
+++ b/src/components/form/fields/ShortNameField.tsx
@@ -1,40 +1,9 @@
 import i18n from '@dhis2/d2-i18n'
 import { InputFieldFF } from '@dhis2/ui'
-import React, { useMemo } from 'react'
+import React from 'react'
 import { Field as FieldRFF, useField } from 'react-final-form'
-import { useParams } from 'react-router-dom'
-import {
-    SchemaSection,
-    composeAsyncValidators,
-    required,
-    useCheckMaxLengthFromSchema,
-    useIsFieldValueUnique,
-} from '../../../lib'
-
-function useValidator({ schemaSection }: { schemaSection: SchemaSection }) {
-    const params = useParams()
-    const modelId = params.id as string
-    const checkIsValueTaken = useIsFieldValueUnique({
-        model: schemaSection.namePlural,
-        field: 'name',
-        id: modelId,
-    })
-
-    const checkMaxLength = useCheckMaxLengthFromSchema(
-        schemaSection.name,
-        'shortName'
-    )
-
-    return useMemo(
-        () =>
-            composeAsyncValidators<string>([
-                checkIsValueTaken,
-                checkMaxLength,
-                required,
-            ]),
-        [checkIsValueTaken, checkMaxLength]
-    )
-}
+import { SchemaSection } from '../../../lib'
+import { useValidator } from '../../../lib/models/useFieldValidators'
 
 export function ShortNameField({
     helpText,
@@ -43,7 +12,7 @@ export function ShortNameField({
     helpText?: string
     schemaSection: SchemaSection
 }) {
-    const validator = useValidator({ schemaSection })
+    const validator = useValidator({ schemaSection, property: 'shortName' })
     const { meta } = useField('shortName', {
         subscription: { validating: true },
     })


### PR DESCRIPTION
Fixes the comment in regards to `shortName` validation: https://dhis2.atlassian.net/browse/DHIS2-18538 

`shortName` used the wrong field to check against: probably due to copy/paste errors. I've updated the common fields `name`, and `shortName` to use the `useValidator` which uses the schema to decide which validation to apply to the fields. This should streamline the validations, and also fixes some discrepancies, because previously `unique` was always checked for `name` - but this is not necessarily correct. Eg. the schema does not define `unique: true` for `organisationUnit` and `dataSets`. 