### PR TITLE
fix: open periods after cat option end date should not allow decimals

### DIFF
--- a/src/pages/dataSetsWip/form/PeriodsFormContents.tsx
+++ b/src/pages/dataSetsWip/form/PeriodsFormContents.tsx
@@ -40,7 +40,8 @@ export const PeriodsContents = ({ name }: { name: string }) => {
                     label={i18n.t(
                         'Close data entry a certain number of days after period end (expiry days)'
                     )}
-                    uncheckedValue={0.0}
+                    uncheckedValue={0}
+                    min={'1'}
                 />
             </StandardFormField>
             {formValues?.categoryCombo.id !== DEFAULT_CATEGORY_COMBO.id && (

--- a/src/pages/dataSetsWip/form/dataSetFormSchema.ts
+++ b/src/pages/dataSetsWip/form/dataSetFormSchema.ts
@@ -26,7 +26,10 @@ export const dataSetFormSchema = identifiable
             .number()
             .int({ message: i18n.t('The number should not have decimals') }),
         expiryDays: z.number(),
-        openPeriodsAfterCoEndDate: z.number().optional(),
+        openPeriodsAfterCoEndDate: z
+            .number()
+            .int({ message: i18n.t('The number should not have decimals') })
+            .optional(),
     })
 
 export const initialValues = getDefaults(dataSetFormSchema)


### PR DESCRIPTION
This change prevents users to fill in decimal numbers for open-period-after-co-end-date dield in datasets