### PR TITLE
fix(router): fix legacy redirect for vite

### DIFF
--- a/src/lib/errors/errors.ts
+++ b/src/lib/errors/errors.ts
@@ -5,5 +5,12 @@ export type ModuleNotFoundError = Error & {
 export const isModuleNotFoundError = (
     error: unknown
 ): error is ModuleNotFoundError => {
+    // vite will throw this error when failing to find a module with dynamic variables
+    if (
+        (error as Error)?.message.startsWith('Unknown variable dynamic import')
+    ) {
+        return true
+    }
+    // webpack will throw an error with code
     return (error as ModuleNotFoundError)?.code === 'MODULE_NOT_FOUND'
 }


### PR DESCRIPTION
This was needed because vite throws a different error when failing to resolve a dynamic import