### PR TITLE
fix: add missing attribute valueTypes

### DIFF
--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -1,0 +1,1 @@
+export * from './valueType'

--- a/src/components/fields/valueType/FormFieldByValueType.tsx
+++ b/src/components/fields/valueType/FormFieldByValueType.tsx
@@ -1,0 +1,55 @@
+import { composeValidators, hasValue, Validator } from '@dhis2/ui'
+import React, { useMemo } from 'react'
+import {
+    FieldProps,
+    FieldRenderProps,
+    Field as FieldRFF,
+} from 'react-final-form'
+import { ValueType } from './types'
+import { getValidateForValueType } from './validateByValueType'
+import { ValueTypeRenderer } from './ValueTypeRenderer'
+
+type CommonFieldProps = {
+    label?: string
+    required?: boolean
+}
+
+export type FormFieldByValueTypeProps = FieldProps<
+    string,
+    FieldRenderProps<string>
+> &
+    CommonFieldProps & {
+        valueType: ValueType
+        validate?: Validator
+    }
+
+export const FormFieldByValueType = (props: FormFieldByValueTypeProps) => {
+    const validate = useMemo(() => {
+        const validateForValueType = getValidateForValueType(props.valueType)
+        const validators = [
+            props.required ? hasValue : undefined,
+            props.validate,
+            validateForValueType,
+        ].filter((v) => !!v)
+
+        return composeValidators(...validators)
+    }, [props.valueType, props.required, props.validate])
+
+    const commonProps = {
+        // if for some reason the valueType is changed during render (it shouldnt)
+        // we reset the component (by using the key) to get updated validators etc
+        ...props,
+        validate,
+    }
+    return (
+        <div style={{ width: '440px' }}>
+            {/* if for some reason the valueType is changed during render (it shouldnt)
+                 we reset the component (by using the key) to get updated validators etc */}
+            <FieldRFF
+                key={props.valueType}
+                {...commonProps}
+                component={ValueTypeRenderer}
+            />
+        </div>
+    )
+}

--- a/src/components/fields/valueType/FormFieldByValueType.tsx
+++ b/src/components/fields/valueType/FormFieldByValueType.tsx
@@ -36,8 +36,6 @@ export const FormFieldByValueType = (props: FormFieldByValueTypeProps) => {
     }, [props.valueType, props.required, props.validate])
 
     const commonProps = {
-        // if for some reason the valueType is changed during render (it shouldnt)
-        // we reset the component (by using the key) to get updated validators etc
         ...props,
         validate,
     }

--- a/src/components/fields/valueType/ValueTypeRenderer.tsx
+++ b/src/components/fields/valueType/ValueTypeRenderer.tsx
@@ -31,10 +31,6 @@ export function ValueTypeRenderer(
         return { id: value }
     }, [value])
 
-    const stableInput = useMemo(() => {
-        return { ...props.input, value: stableIdValue }
-    }, [props.input, stableIdValue])
-
     if (valueType === 'BOOLEAN' || valueType === 'TRUE_ONLY') {
         return (
             <CheckboxFieldFF

--- a/src/components/fields/valueType/ValueTypeRenderer.tsx
+++ b/src/components/fields/valueType/ValueTypeRenderer.tsx
@@ -1,0 +1,125 @@
+import i18n from '@dhis2/d2-i18n'
+import { CheckboxFieldFF, InputFieldFF, TextAreaFieldFF } from '@dhis2/ui'
+import React, { useMemo } from 'react'
+import { FieldRenderProps } from 'react-final-form'
+import { ModelSingleSelectField } from '../../metadataFormControls/ModelSingleSelect'
+import { ValueType } from './types'
+
+type CommonFieldProps = {
+    label?: string
+    required?: boolean
+}
+
+type FinalFormFieldProps = Pick<FieldRenderProps<string>, 'input' | 'meta'>
+
+/**
+ * A component that renders an underlying Field based on the valueType
+ *
+ * Note that this is not bound to a form - but it follows the API of ReactFinalForm
+ *  eg. using input and meta
+ * The output of all fields is a string (eg. onChange) should be a string
+ */
+export function ValueTypeRenderer(
+    props: CommonFieldProps & FinalFormFieldProps & { valueType: ValueType }
+) {
+    const valueType = props.valueType
+    const value = props.input.value
+
+    // ModelSingleSelects needs value to be an object, but the value from field is an id
+    // so keep this stable
+    const stableIdValue = useMemo(() => {
+        return { id: value }
+    }, [value])
+
+    const stableInput = useMemo(() => {
+        return { ...props.input, value: stableIdValue }
+    }, [props.input, stableIdValue])
+
+    if (valueType === 'BOOLEAN' || valueType === 'TRUE_ONLY') {
+        return (
+            <CheckboxFieldFF
+                {...props}
+                type="checkbox"
+                input={{
+                    ...props.input,
+                    checked: value === 'true',
+                    onChange: (e) => {
+                        const falseValue =
+                            valueType === 'BOOLEAN' ? 'false' : undefined
+                        props.input.onChange(
+                            e.target.checked ? 'true' : falseValue
+                        )
+                    },
+                }}
+            />
+        )
+    }
+
+    if (valueType === 'TEXT') {
+        return <InputFieldFF {...props} />
+    }
+    if (valueType === 'LONG_TEXT') {
+        return <TextAreaFieldFF {...props} />
+    }
+
+    if (valueType === 'NUMBER' || valueType === 'INTEGER') {
+        return (
+            <InputFieldFF
+                {...props}
+                input={{
+                    ...props.input,
+                    type: 'number',
+                }}
+            />
+        )
+    }
+
+    if (valueType === 'GEOJSON') {
+        return (
+            <TextAreaFieldFF
+                {...props}
+                resize="both"
+                helpText={i18n.t('Please enter a GeoJSON value')}
+            />
+        )
+    }
+
+    if (valueType === 'FILE_RESOURCE') {
+        return (
+            <ModelSingleSelectField
+                {...props}
+                query={{
+                    resource: 'fileResources',
+                }}
+                input={{
+                    ...props.input,
+                    value: stableIdValue,
+                    onChange: (e) => {
+                        props.input.onChange(e?.id)
+                    },
+                    onBlur: props.input.onBlur,
+                }}
+            />
+        )
+    }
+
+    if (valueType === 'ORGANISATION_UNIT') {
+        return (
+            <ModelSingleSelectField
+                {...props}
+                query={{
+                    resource: 'organisationUnits',
+                }}
+                input={{
+                    ...props.input,
+                    value: stableIdValue,
+                    onChange: (e) => {
+                        props.input.onChange(e?.id)
+                    },
+                }}
+            />
+        )
+    }
+    // render a regular input field if not overridden above
+    return <InputFieldFF {...props} />
+}

--- a/src/components/fields/valueType/index.ts
+++ b/src/components/fields/valueType/index.ts
@@ -1,0 +1,2 @@
+export * from './FormFieldByValueType'
+export * from './validateByValueType'

--- a/src/components/fields/valueType/types.ts
+++ b/src/components/fields/valueType/types.ts
@@ -1,0 +1,3 @@
+import { VALUE_TYPE } from '../../../lib'
+
+export type ValueType = keyof typeof VALUE_TYPE

--- a/src/components/fields/valueType/validateByValueType.ts
+++ b/src/components/fields/valueType/validateByValueType.ts
@@ -47,10 +47,13 @@ const VALUE_TYPE_VALIDATE = {
         return i18n.t('Please provide valid unit interval (0-1).')
     }),
     AGE: number,
+    // backend has a more thorough check, but it also specifies length between 6 and 50
+    // ref: https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/attribute/DefaultAttributeValidator.java#L86
     PHONE_NUMBER: createCharacterLengthRange(6, 50),
     URL: url,
-    // TRUE_ONLY: (value: unknown) =>
-    //     value === 'true' ? undefined : 'Must be true',
+    //true_only doesnt make much sense imo, but this is what the backend is doing...
+    TRUE_ONLY: (value: unknown) =>
+        value === 'true' ? undefined : 'Must be true',
     EMAIL: email,
 } satisfies Partial<Record<ValueType, Validator>>
 

--- a/src/components/fields/valueType/validateByValueType.ts
+++ b/src/components/fields/valueType/validateByValueType.ts
@@ -1,0 +1,66 @@
+import i18n from '@dhis2/d2-i18n'
+import {
+    composeValidators,
+    createCharacterLengthRange,
+    email,
+    integer,
+    number,
+    url,
+    Validator,
+} from '@dhis2/ui'
+import { ValueType } from './types'
+
+const VALUE_TYPE_VALIDATE = {
+    NUMBER: number,
+    INTEGER: integer,
+    INTEGER_POSITIVE: composeValidators(integer, (value) =>
+        typeof value === 'string' && parseInt(value) > 0
+            ? undefined
+            : i18n.t('Please provide a positive integer')
+    ),
+    INTEGER_NEGATIVE: composeValidators(integer, (value) =>
+        typeof value === 'string' && parseInt(value) < 0
+            ? undefined
+            : i18n.t('Please provide a negative integer')
+    ),
+    INTEGER_ZERO_OR_POSITIVE: composeValidators(integer, (value) =>
+        typeof value === 'string' && parseInt(value) < 0
+            ? undefined
+            : i18n.t('Please provide a 0 or positive integer')
+    ),
+    PERCENTAGE: composeValidators(number, (value) => {
+        if (typeof value === 'string') {
+            const numberValue = parseFloat(value)
+            if (numberValue >= 0 || numberValue <= 100) {
+                return undefined
+            }
+        }
+        return i18n.t('Please provide valid percantage (0-100).')
+    }),
+    UNIT_INTERVAL: composeValidators(number, (value) => {
+        if (typeof value === 'string') {
+            const numberValue = parseFloat(value)
+            if (numberValue >= 0 || numberValue <= 1) {
+                return undefined
+            }
+        }
+        return i18n.t('Please provide valid unit interval (0-1).')
+    }),
+    AGE: number,
+    PHONE_NUMBER: createCharacterLengthRange(6, 50),
+    URL: url,
+    // TRUE_ONLY: (value: unknown) =>
+    //     value === 'true' ? undefined : 'Must be true',
+    EMAIL: email,
+} satisfies Partial<Record<ValueType, Validator>>
+
+export const getValidateForValueType = (
+    valueType: string
+): Validator | undefined => {
+    if (valueType in VALUE_TYPE_VALIDATE) {
+        return VALUE_TYPE_VALIDATE[
+            valueType as keyof typeof VALUE_TYPE_VALIDATE
+        ]
+    }
+    return undefined
+}

--- a/src/components/fields/valueType/validateByValueType.ts
+++ b/src/components/fields/valueType/validateByValueType.ts
@@ -53,7 +53,7 @@ const VALUE_TYPE_VALIDATE = {
     URL: url,
     //true_only doesnt make much sense imo, but this is what the backend is doing...
     TRUE_ONLY: (value: unknown) =>
-        value === 'true' ? undefined : 'Must be true',
+        value === 'true' ? undefined : i18n.t('Must be checked'),
     EMAIL: email,
 } satisfies Partial<Record<ValueType, Validator>>
 

--- a/src/components/form/attributes/CustomAttributes.tsx
+++ b/src/components/form/attributes/CustomAttributes.tsx
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { InputFieldFF, SingleSelectFieldFF, TextAreaFieldFF } from '@dhis2/ui'
+import { SingleSelectFieldFF } from '@dhis2/ui'
 import * as React from 'react'
 import { Field as FieldRFF, useFormState } from 'react-final-form'
 import {

--- a/src/components/form/attributes/CustomAttributes.tsx
+++ b/src/components/form/attributes/CustomAttributes.tsx
@@ -10,6 +10,7 @@ import {
 } from '../..'
 import { SchemaSection } from '../../../types'
 import { Attribute, AttributeValue } from '../../../types/generated'
+import { FormFieldByValueType } from '../../fields'
 
 const inputWidth = '440px'
 
@@ -52,50 +53,16 @@ function CustomAttribute({ attribute, index }: CustomAttributeProps) {
         )
     }
 
-    if (attribute.valueType === 'TEXT') {
-        return (
-            <StandardFormField key={attribute.id}>
-                <FieldRFF
-                    component={InputFieldFF}
-                    required={required}
-                    inputWidth={inputWidth}
-                    label={attribute.displayFormName}
-                    name={name}
-                />
-            </StandardFormField>
-        )
-    }
-
-    if (attribute.valueType === 'LONG_TEXT') {
-        return (
-            <StandardFormField key={attribute.id}>
-                <FieldRFF
-                    component={TextAreaFieldFF}
-                    required={required}
-                    inputWidth={inputWidth}
-                    label={attribute.displayFormName}
-                    name={name}
-                />
-            </StandardFormField>
-        )
-    }
-
-    if (attribute.valueType === 'GEOJSON') {
-        return (
-            <StandardFormField key={attribute.id}>
-                <FieldRFF
-                    component={TextAreaFieldFF}
-                    required={required}
-                    inputWidth={inputWidth}
-                    label={attribute.displayFormName}
-                    name={name}
-                    helpText={i18n.t('Please enter a GeoJSON value.')}
-                />
-            </StandardFormField>
-        )
-    }
-    // @TODO: Verify that all value types have been covered!
-    throw new Error(`Implement value type "${attribute.valueType}"!`)
+    return (
+        <StandardFormField key={attribute.id}>
+            <FormFieldByValueType
+                valueType={attribute.valueType}
+                name={name}
+                label={attribute.displayFormName}
+                required={required}
+            />
+        </StandardFormField>
+    )
 }
 
 export function CustomAttributesSection({

--- a/src/components/merge/MergeFieldsBase.tsx
+++ b/src/components/merge/MergeFieldsBase.tsx
@@ -4,10 +4,10 @@ import { useField } from 'react-final-form'
 import { PlainResourceQuery, Optional } from '../../types'
 import { DisplayableModel } from '../../types/models'
 import {
-    ModelMultiSelectField,
     ModelMultiSelectFieldProps,
+    ModelMultiSelectFormField,
 } from '../metadataFormControls'
-import { ModelSingleSelectField } from '../metadataFormControls/ModelSingleSelect'
+import { ModelSingleSelectFormField } from '../metadataFormControls/ModelSingleSelect'
 import css from './MergeFields.module.css'
 
 type BaseSourceFieldProps = Optional<
@@ -22,7 +22,7 @@ export const BaseSourcesField = (props: BaseSourceFieldProps) => {
     }).input.value
 
     return (
-        <ModelMultiSelectField
+        <ModelMultiSelectFormField
             name="sources"
             label="Sources"
             maxHeight="150px"
@@ -52,7 +52,7 @@ export const BaseTargetField = ({
     }).input.value
 
     return (
-        <ModelSingleSelectField
+        <ModelSingleSelectFormField
             name="target"
             query={query}
             transform={(availableData) =>

--- a/src/components/metadataFormControls/ModelMultiSelect/ModelMultiSelectField.tsx
+++ b/src/components/metadataFormControls/ModelMultiSelect/ModelMultiSelectField.tsx
@@ -5,11 +5,6 @@ import { PlainResourceQuery } from '../../../types'
 import { DisplayableModel } from '../../../types/models'
 import { ModelMultiSelectProps, ModelMultiSelect } from './ModelMultiSelect'
 
-type RFFProps<TModel extends DisplayableModel> = FieldRenderProps<
-    TModel[] | undefined,
-    HTMLElement
->
-
 type RelevantRenderProps<TModel extends DisplayableModel> = {
     input: Pick<
         FieldRenderProps<TModel[] | undefined>['input'],
@@ -48,10 +43,6 @@ export function ModelMultiSelectField<TModel extends DisplayableModel>({
     meta,
     ...modelSingleSelectProps
 }: ModelMultiSelectFieldProps<TModel> & RelevantRenderProps<TModel>) {
-    // const { input, meta } = useField<TModel[] | undefined>(name, {
-    //     validateFields: [],
-    // })
-
     return (
         <Field
             dataTest={`formfields-modelmultiselect-${name}`}

--- a/src/components/metadataFormControls/ModelMultiSelect/ModelMultiSelectField.tsx
+++ b/src/components/metadataFormControls/ModelMultiSelect/ModelMultiSelectField.tsx
@@ -1,9 +1,25 @@
 import { Field } from '@dhis2/ui'
 import React from 'react'
-import { useField } from 'react-final-form'
+import { FieldRenderProps, useField } from 'react-final-form'
 import { PlainResourceQuery } from '../../../types'
 import { DisplayableModel } from '../../../types/models'
 import { ModelMultiSelectProps, ModelMultiSelect } from './ModelMultiSelect'
+
+type RFFProps<TModel extends DisplayableModel> = FieldRenderProps<
+    TModel[] | undefined,
+    HTMLElement
+>
+
+type RelevantRenderProps<TModel extends DisplayableModel> = {
+    input: Pick<
+        FieldRenderProps<TModel[] | undefined>['input'],
+        'value' | 'onChange' | 'onBlur'
+    >
+    meta: Pick<
+        FieldRenderProps<TModel[] | undefined>['meta'],
+        'invalid' | 'touched' | 'error'
+    >
+}
 
 type OwnProps<TModel extends DisplayableModel> = {
     name: string
@@ -28,11 +44,13 @@ export function ModelMultiSelectField<TModel extends DisplayableModel>({
     helpText,
     required,
     onChange,
+    input,
+    meta,
     ...modelSingleSelectProps
-}: ModelMultiSelectFieldProps<TModel>) {
-    const { input, meta } = useField<TModel[] | undefined>(name, {
-        validateFields: [],
-    })
+}: ModelMultiSelectFieldProps<TModel> & RelevantRenderProps<TModel>) {
+    // const { input, meta } = useField<TModel[] | undefined>(name, {
+    //     validateFields: [],
+    // })
 
     return (
         <Field
@@ -55,5 +73,23 @@ export function ModelMultiSelectField<TModel extends DisplayableModel>({
                 query={query}
             />
         </Field>
+    )
+}
+
+export function ModelMultiSelectFormField<TModel extends DisplayableModel>({
+    name,
+    ...modelSingleSelectProps
+}: ModelMultiSelectFieldProps<TModel>) {
+    const { input, meta } = useField<TModel[] | undefined>(name, {
+        validateFields: [],
+    })
+
+    return (
+        <ModelMultiSelectField
+            name={name}
+            input={input}
+            meta={meta}
+            {...modelSingleSelectProps}
+        />
     )
 }

--- a/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
@@ -88,7 +88,9 @@ export const ModelSingleSelect = <
         !!selected &&
         selected.displayName === undefined &&
         !!selected.id &&
+        resolvedAvailable.length > 0 &&
         resolvedAvailable.find((a) => a.id === selected.id) === undefined
+
     // if we just have the ID - fetch the displayName
     const selectedQuery = useQuery({
         queryKey: [
@@ -109,6 +111,7 @@ export const ModelSingleSelect = <
         if (
             !selected ||
             !selectedQuery.data ||
+            !shouldFetchSelected ||
             selected?.displayName !== undefined
         ) {
             return
@@ -116,7 +119,7 @@ export const ModelSingleSelect = <
         // if we had to fetch the selected model, call the onChange
         // to update store with the full model
         onChange?.(selectedQuery.data)
-    }, [selectedQuery.data, selected, onChange])
+    }, [selectedQuery.data, shouldFetchSelected, selected, onChange])
 
     const resolvedSelected =
         shouldFetchSelected && selectedQuery.data

--- a/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelectField.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelectField.tsx
@@ -1,11 +1,13 @@
 import { Field } from '@dhis2/ui'
 import React from 'react'
-import { useField, UseFieldConfig } from 'react-final-form'
-import { DisplayableModel } from '../../../types/models'
+import { FieldRenderProps, useField, UseFieldConfig } from 'react-final-form'
+import {
+    DisplayableModel,
+    PartialLoadedDisplayableModel,
+} from '../../../types/models'
 import { ModelSingleSelectProps, ModelSingleSelect } from './ModelSingleSelect'
 
-type OwnProps<TModel extends DisplayableModel> = {
-    name: string
+type OwnProps<TModel extends PartialLoadedDisplayableModel> = {
     label?: string
     placeholder?: string
     helpText?: string
@@ -13,47 +15,51 @@ type OwnProps<TModel extends DisplayableModel> = {
     onChange?: ModelSingleSelectProps<TModel>['onChange']
 }
 
-type RelevantUseFieldProps<TModel extends DisplayableModel> = Pick<
+type RelevantRenderProps<TModel extends PartialLoadedDisplayableModel> = {
+    input: Pick<
+        FieldRenderProps<TModel | undefined>['input'],
+        'value' | 'onChange' | 'onBlur' | 'name'
+    >
+    meta: Pick<
+        FieldRenderProps<TModel | undefined>['meta'],
+        'invalid' | 'touched' | 'error'
+    >
+}
+type RelevantUseFieldProps<TModel extends PartialLoadedDisplayableModel> = Pick<
     UseFieldConfig<TModel | undefined>,
     'validate' | 'validateFields' | 'initialValue' | 'format' | 'parse' | 'data'
->
+> & {
+    name: string
+}
 
 export type ModelSingleSelectFieldProps<
-    TModel extends DisplayableModel = DisplayableModel
+    TModel extends PartialLoadedDisplayableModel = DisplayableModel
 > = Omit<ModelSingleSelectProps<TModel>, 'selected' | 'onChange'> &
-    OwnProps<TModel> &
-    RelevantUseFieldProps<TModel>
-
-export function ModelSingleSelectField<TModel extends DisplayableModel>({
-    name,
+    OwnProps<TModel>
+export function ModelSingleSelectField<
+    TModel extends PartialLoadedDisplayableModel
+>({
     label,
     helpText,
     required,
     onChange,
     // react-final-form props
-    validate,
-    validateFields,
-    initialValue,
-    format,
-    parse,
-    data,
+    // validate,
+    // validateFields,
+    // initialValue,
+    // format,
+    // parse,
+    // data,
+    input,
+    meta,
     ...modelSingleSelectProps
-}: ModelSingleSelectFieldProps<TModel>) {
-    const { input, meta } = useField<TModel | undefined>(name, {
-        validateFields: validateFields ?? [],
-        validate,
-        initialValue,
-        format,
-        parse,
-        data,
-    })
-
+}: ModelSingleSelectFieldProps<TModel> & RelevantRenderProps<TModel>) {
     return (
         <Field
             dataTest={`formfields-modelsingleselect-${name}`}
             error={meta.invalid}
             validationText={(meta.touched && meta.error?.toString()) || ''}
-            name={name}
+            name={input.name}
             label={label}
             helpText={helpText}
             required={required}
@@ -69,5 +75,34 @@ export function ModelSingleSelectField<TModel extends DisplayableModel>({
                 invalid={meta.touched && !!meta.error}
             />
         </Field>
+    )
+}
+
+export function ModelSingleSelectFormField<TModel extends DisplayableModel>({
+    // react-final-form props
+    name,
+    validateFields,
+    validate,
+    initialValue,
+    format,
+    parse,
+    data,
+    ...modelSingleSelectProps
+}: ModelSingleSelectFieldProps<TModel> & RelevantUseFieldProps<TModel>) {
+    const { input, meta } = useField<TModel | undefined>(name, {
+        validateFields: validateFields ?? [],
+        validate,
+        initialValue,
+        format,
+        parse,
+        data,
+    })
+
+    return (
+        <ModelSingleSelectField
+            input={input}
+            meta={meta}
+            {...modelSingleSelectProps}
+        />
     )
 }

--- a/src/pages/dataSetsWip/form/CategoryComboField.tsx
+++ b/src/pages/dataSetsWip/form/CategoryComboField.tsx
@@ -2,7 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import React from 'react'
 import {
     ModelSingleSelect,
-    ModelSingleSelectField,
+    ModelSingleSelectFormField,
     ModelSingleSelectProps,
 } from '../../../components/metadataFormControls/ModelSingleSelect'
 import { DEFAULT_CATEGORY_COMBO } from '../../../lib'
@@ -27,7 +27,7 @@ const addDefaultCategoryComboTransform = <TCatCombo extends DisplayableModel>(
 
 export function CategoryComboField() {
     return (
-        <ModelSingleSelectField
+        <ModelSingleSelectFormField
             required
             name="categoryCombo"
             label={i18n.t('{{fieldLabel}} (required)', {


### PR DESCRIPTION
Fixes [DHIS2-18194](https://dhis2.atlassian.net/browse/DHIS2-18194)

This implements more `valueType`-fields for attributes, but most importantly falls back to a simple input field instead of throwing an error. 
I wanted to decouple the valueTypes renderer from attributes itself. This is because `valueTypes` can also be used in eg. options of optionSets, rather than just for attributes - so I've moved this to it's own "concept/folder".
I also wanted to decouple the rendered field from `final-form`, eg. instead of rendering fields bound to the form, the `ValueTypeRenderer` is not connected to the form (much like FF fields from UI). 
 I've added a convenient wrapper to final form with `FormFieldByValueType`-component. 


[DHIS2-18194]: https://dhis2.atlassian.net/browse/DHIS2-18194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ