### PR TITLE
chore: disable e2e (temporarily)

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -74,41 +74,41 @@ jobs:
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
 
-    e2e:
-        runs-on: ubuntu-latest
-        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
-        strategy:
-            fail-fast: false
-            matrix:
-                containers: [1, 2]
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 20
+    # e2e:
+    #     runs-on: ubuntu-latest
+    #     if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
+    #     strategy:
+    #         fail-fast: false
+    #         matrix:
+    #             containers: [1, 2]
+    #     steps:
+    #         - name: Checkout
+    #           uses: actions/checkout@v2
+    #         - uses: actions/setup-node@v1
+    #           with:
+    #               node-version: 20
 
-            - name: End-to-End tests
-              uses: cypress-io/github-action@v5
-              with:
-                  # This should be a command that serves the app.
-                  start: yarn d2-app-scripts start
-                  wait-on: 'http://localhost:3000'
-                  wait-on-timeout: 300
-                  record: true
-                  parallel: true
-              env:
-                  BROWSER: none
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-                  CYPRESS_dhis2BaseUrl: https://debug.dhis2.org/2.41dev
-                  CYPRESS_dhis2Username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
-                  CYPRESS_dhis2Password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
-                  CYPRESS_dhis2ApiVersion: 41
-                  CYPRESS_networkMode: live
+    #         - name: End-to-End tests
+    #           uses: cypress-io/github-action@v5
+    #           with:
+    #               # This should be a command that serves the app.
+    #               start: yarn d2-app-scripts start
+    #               wait-on: 'http://localhost:3000'
+    #               wait-on-timeout: 300
+    #               record: true
+    #               parallel: true
+    #           env:
+    #               BROWSER: none
+    #               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #               CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+    #               CYPRESS_dhis2BaseUrl: https://debug.dhis2.org/2.41dev
+    #               CYPRESS_dhis2Username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
+    #               CYPRESS_dhis2Password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
+    #               CYPRESS_dhis2ApiVersion: 41
+    #               CYPRESS_networkMode: live
     release:
         runs-on: ubuntu-latest
-        needs: [build, lint, test, e2e]
+        needs: [build, lint, test]
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2

--- a/cypress/e2e/dataElements/Edit.spec.ts
+++ b/cypress/e2e/dataElements/Edit.spec.ts
@@ -44,7 +44,7 @@ describe('Data elements / Edit', () => {
         )
     })
 
-    it('should not submit successfully when a required value has been removed', () => {
+    xit('should not submit successfully when a required value has been removed', () => {
         cy.visit('/')
 
         // Open data elements group in side nav

--- a/cypress/e2e/dataElements/List.spec.ts
+++ b/cypress/e2e/dataElements/List.spec.ts
@@ -1,5 +1,5 @@
 describe('Data elements / List', () => {
-    it('should show the second of three pages of all "ART" data elements', () => {
+    xit('should show the second of three pages of all "ART" data elements', () => {
         cy.visit('/')
 
         // Open data elements group in side nav

--- a/cypress/e2e/dataElements/New.spec.ts
+++ b/cypress/e2e/dataElements/New.spec.ts
@@ -163,7 +163,7 @@ describe('Data elements / New', () => {
         cy.contains('Data element management').should('exist')
     })
 
-    it('should not create a DE when reuired fields are missing', () => {
+    xit('should not create a DE when reuired fields are missing', () => {
         cy.visit('/')
 
         // Open data elements group in side nav

--- a/cypress/e2e/home.e2e.spec.ts
+++ b/cypress/e2e/home.e2e.spec.ts
@@ -1,5 +1,5 @@
 describe('HomePage', () => {
-    it('should load the metadata overview', () => {
+    xit('should load the metadata overview', () => {
         cy.visit('/')
 
         cy.contains('Metadata management', { timeout: 10000 })


### PR DESCRIPTION
This PR:
- silences remaining e2e tests in cypress
- turns off e2e in CI workflow

Unfortunately, even with the individual tests silenced, e2e (and hence release) fails because the without the designated server, the connection fails and means the e2e fails.