### PR TITLE
fix: add max selections to compuslory data element operands

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-02-28T08:48:54.069Z\n"
-"PO-Revision-Date: 2025-02-28T08:48:54.070Z\n"
+"POT-Creation-Date: 2025-03-06T15:14:09.076Z\n"
+"PO-Revision-Date: 2025-03-06T15:14:09.077Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -604,12 +604,6 @@ msgstr "Organisation unit"
 
 msgid "Organisation units"
 msgstr "Organisation units"
-
-msgid "Organisation unit level"
-msgstr "Organisation unit level"
-
-msgid "Organisation unit levels"
-msgstr "Organisation unit levels"
 
 msgid "Organisation unit group"
 msgstr "Organisation unit group"
@@ -1494,6 +1488,21 @@ msgstr "Search available legends"
 msgid "Search selected legends"
 msgstr "Search selected legends"
 
+msgid "Available data elements"
+msgstr "Available data elements"
+
+msgid "Compulsory data elements"
+msgstr "Compulsory data elements"
+
+msgid "Search available data elements"
+msgstr "Search available data elements"
+
+msgid "Search compulsory data elements"
+msgstr "Search compulsory data elements"
+
+msgid "Approval workflow"
+msgstr "Approval workflow"
+
 msgid "Configure data elements"
 msgstr "Configure data elements"
 
@@ -1634,6 +1643,32 @@ msgstr "Validation and limitations"
 msgid "Configure how data can and must be entered for this data"
 msgstr "Configure how data can and must be entered for this data"
 
+msgid "Completing a data set requires passing validation"
+msgstr "Completing a data set requires passing validation"
+
+msgid "Completing a data set requires all empty values to have a comment"
+msgstr "Completing a data set requires all empty values to have a comment"
+
+msgid "Completing a data set requires compulsory field to have a value"
+msgstr "Completing a data set requires compulsory field to have a value"
+
+msgid ""
+"Data elements with category combinations require all fields to have a value "
+"if one has a value"
+msgstr ""
+"Data elements with category combinations require all fields to have a value "
+"if one has a value"
+
+msgid "Compulsory data entry"
+msgstr "Compulsory data entry"
+
+msgid ""
+"Optionally configure which data elements must have a value to complete this "
+"data set."
+msgstr ""
+"Optionally configure which data elements must have a value to complete this "
+"data set."
+
 msgid "Add period entry rule"
 msgstr "Add period entry rule"
 
@@ -1672,32 +1707,6 @@ msgstr "Remove"
 
 msgid "Add a period entry rule"
 msgstr "Add a period entry rule"
-
-msgid "Completing a data set requires passing validation"
-msgstr "Completing a data set requires passing validation"
-
-msgid "Completing a data set requires all empty values to have a comment"
-msgstr "Completing a data set requires all empty values to have a comment"
-
-msgid "Completing a data set requires compulsory field to have a value"
-msgstr "Completing a data set requires compulsory field to have a value"
-
-msgid ""
-"Data elements with category combinations require all fields to have a value "
-"if one has a value"
-msgstr ""
-"Data elements with category combinations require all fields to have a value "
-"if one has a value"
-
-msgid "Compulsory data entry"
-msgstr "Compulsory data entry"
-
-msgid ""
-"Optionally configure which data elements must have a value to complete this "
-"data set."
-msgstr ""
-"Optionally configure which data elements must have a value to complete this "
-"data set."
 
 msgid "The number should not have decimals"
 msgstr "The number should not have decimals"

--- a/src/pages/dataSetsWip/form/CompulsoryDataElementsTransfer.tsx
+++ b/src/pages/dataSetsWip/form/CompulsoryDataElementsTransfer.tsx
@@ -58,6 +58,7 @@ export const CompulsoryDataElementsTransfer = () => {
             height="350px"
             optionsWidth="500px"
             selectedWidth="500px"
+            maxSelections={Infinity}
             renderOption={({ value, ...rest }) => {
                 const catOptComboName =
                     value.categoryOptionCombo.displayName === 'default'


### PR DESCRIPTION
Allows all selection on compulsory data element operands transfer (fixes testing issue: https://dhis2.atlassian.net/browse/DHIS2-18707?focusedCommentId=210746)