### PR TITLE
fix: display information when no target is available [BETA-348]

### DIFF
--- a/src/components/SearchableSingleSelect/SearchableSingleSelect.module.css
+++ b/src/components/SearchableSingleSelect/SearchableSingleSelect.module.css
@@ -66,3 +66,12 @@
     color: var(--theme-valid);
     text-decoration: none;
 }
+
+.noMatchBlock {
+    color: var(--colors-grey700);
+    font-size: 13px;
+    line-height: 16px;
+    padding-block: var(--spacers-dp8);
+    padding-inline: var(--spacers-dp24);
+    text-align: center;
+}

--- a/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
+++ b/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
@@ -66,6 +66,7 @@ export interface SearchableSingleSelectPropTypes {
     onBlur?: () => void
     onFocus?: () => void
     searchable?: boolean
+    noMatchWithoutFilterText?: string
 }
 
 export const SearchableSingleSelect = ({
@@ -87,6 +88,7 @@ export const SearchableSingleSelect = ({
     showAllOption,
     showEndLoader,
     searchable = true,
+    noMatchWithoutFilterText,
 }: SearchableSingleSelectPropTypes) => {
     const [loadingSpinnerRef, setLoadingSpinnerRef] = useState<HTMLElement>()
 
@@ -141,19 +143,29 @@ export const SearchableSingleSelect = ({
             dense={dense}
         >
             {searchable && (
-                <div className={classes.searchField}>
-                    <div className={classes.searchInput}>
-                        <Input
-                            dense
-                            initialFocus
-                            value={filter}
-                            onChange={({ value }) =>
-                                setFilterValue(value ?? '')
-                            }
-                            placeholder={i18n.t('Filter options')}
-                            type="search"
-                        />
+                <>
+                    <div className={classes.searchField}>
+                        <div className={classes.searchInput}>
+                            <Input
+                                dense
+                                initialFocus
+                                value={filter}
+                                onChange={({ value }) =>
+                                    setFilterValue(value ?? '')
+                                }
+                                placeholder={i18n.t('Filter options')}
+                                type="search"
+                            />
+                        </div>
                     </div>
+                </>
+            )}
+
+            {withAllOptions.length === 0 && (
+                <div className={classes.noMatchBlock}>
+                    {!filter && noMatchWithoutFilterText
+                        ? noMatchWithoutFilterText
+                        : 'No matches'}
                 </div>
             )}
 

--- a/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
+++ b/src/components/SearchableSingleSelect/SearchableSingleSelect.tsx
@@ -143,22 +143,20 @@ export const SearchableSingleSelect = ({
             dense={dense}
         >
             {searchable && (
-                <>
-                    <div className={classes.searchField}>
-                        <div className={classes.searchInput}>
-                            <Input
-                                dense
-                                initialFocus
-                                value={filter}
-                                onChange={({ value }) =>
-                                    setFilterValue(value ?? '')
-                                }
-                                placeholder={i18n.t('Filter options')}
-                                type="search"
-                            />
-                        </div>
+                <div className={classes.searchField}>
+                    <div className={classes.searchInput}>
+                        <Input
+                            dense
+                            initialFocus
+                            value={filter}
+                            onChange={({ value }) =>
+                                setFilterValue(value ?? '')
+                            }
+                            placeholder={i18n.t('Filter options')}
+                            type="search"
+                        />
                     </div>
-                </>
+                </div>
             )}
 
             {withAllOptions.length === 0 && (

--- a/src/components/merge/MergeFieldsBase.tsx
+++ b/src/components/merge/MergeFieldsBase.tsx
@@ -40,12 +40,14 @@ type BaseTargetFieldProps = {
     query: PlainResourceQuery
     label?: string
     placeholder?: string
+    noMatchWithoutFilterText?: string
 }
 
 export const BaseTargetField = ({
     query,
     label,
     placeholder,
+    noMatchWithoutFilterText,
 }: BaseTargetFieldProps) => {
     const sourcesValues = useField<DisplayableModel[]>('sources', {
         subscription: { value: true },
@@ -62,6 +64,10 @@ export const BaseTargetField = ({
             }
             label={label || 'Target'}
             placeholder={placeholder || 'Select the model to merge into'}
+            noMatchWithoutFilterText={
+                noMatchWithoutFilterText ??
+                'No potential targets available. Remove an item from sources.'
+            }
         />
     )
 }

--- a/src/components/metadataFormControls/ModelSingleSelect/BaseModelSingleSelect.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/BaseModelSingleSelect.tsx
@@ -33,7 +33,6 @@ export const BaseModelSingleSelect = <
 >({
     available,
     selected,
-    noMatchWithoutFilterText,
     onChange,
     showNoValueOption,
     ...searchableSingleSelectProps
@@ -76,7 +75,6 @@ export const BaseModelSingleSelect = <
             selected={selected?.id}
             options={allSingleSelectOptions}
             onChange={handleOnChange}
-            noMatchWithoutFilterText={noMatchWithoutFilterText}
         />
     )
 }

--- a/src/components/metadataFormControls/ModelSingleSelect/BaseModelSingleSelect.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/BaseModelSingleSelect.tsx
@@ -16,6 +16,7 @@ type OwnProps<TModel> = {
     available: TModel[]
     onChange: (selected: TModel | undefined) => void
     showNoValueOption?: { value: string; label: string } | boolean
+    noMatchWithoutFilterText?: string
 }
 
 export type BaseModelSingleSelectProps<
@@ -32,6 +33,7 @@ export const BaseModelSingleSelect = <
 >({
     available,
     selected,
+    noMatchWithoutFilterText,
     onChange,
     showNoValueOption,
     ...searchableSingleSelectProps
@@ -74,6 +76,7 @@ export const BaseModelSingleSelect = <
             selected={selected?.id}
             options={allSingleSelectOptions}
             onChange={handleOnChange}
+            noMatchWithoutFilterText={noMatchWithoutFilterText}
         />
     )
 }

--- a/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
@@ -1,5 +1,4 @@
 import i18n from '@dhis2/d2-i18n'
-import { NoticeBox } from '@dhis2/ui'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
@@ -37,6 +36,7 @@ export type ModelSingleSelectProps<
     query: Omit<PlainResourceQuery, 'id'>
     onFilterChange?: (value: string) => void
     transform?: (value: TModel[]) => TModel[]
+    noMatchWithoutFilterText?: string
 }
 
 export const ModelSingleSelect = <
@@ -45,6 +45,7 @@ export const ModelSingleSelect = <
     selected,
     query,
     transform,
+    noMatchWithoutFilterText,
     ...baseModelSingleSelectProps
 }: ModelSingleSelectProps<TModel>) => {
     const queryFn = useBoundResourceQueryFn()
@@ -145,20 +146,6 @@ export const ModelSingleSelect = <
         baseModelSingleSelectProps.onFilterChange?.(value)
     }, 250)
 
-    if (
-        resolvedAvailable.length === 0 &&
-        filter.length === 0 &&
-        !queryResult.hasNextPage
-    ) {
-        return (
-            <NoticeBox warning>
-                {i18n.t(
-                    'There is nothing available to select. Remove a source item.'
-                )}
-            </NoticeBox>
-        )
-    }
-
     return (
         <BaseModelSingleSelect
             {...baseModelSingleSelectProps}
@@ -170,6 +157,7 @@ export const ModelSingleSelect = <
             onEndReached={queryResult.fetchNextPage}
             loading={queryResult.isLoading}
             error={queryResult.error?.toString()}
+            noMatchWithoutFilterText={noMatchWithoutFilterText}
         />
     )
 }

--- a/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
@@ -1,3 +1,5 @@
+import i18n from '@dhis2/d2-i18n'
+import { NoticeBox } from '@dhis2/ui'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
@@ -84,6 +86,16 @@ export const ModelSingleSelect = <
         return transform ? transform(allDataMap) : allDataMap
     }, [allDataMap, transform])
 
+    useEffect(() => {
+        // fetch until we have resolvedAvailable length equal to the desired page size (or until we reach the end)
+        if (
+            resolvedAvailable.length < (queryObject.params.pageSize ?? 10) &&
+            queryResult.hasNextPage
+        ) {
+            queryResult.fetchNextPage()
+        }
+    }, [resolvedAvailable])
+
     const shouldFetchSelected =
         !!selected &&
         selected.displayName === undefined &&
@@ -132,6 +144,20 @@ export const ModelSingleSelect = <
         }
         baseModelSingleSelectProps.onFilterChange?.(value)
     }, 250)
+
+    if (
+        resolvedAvailable.length === 0 &&
+        filter.length === 0 &&
+        !queryResult.hasNextPage
+    ) {
+        return (
+            <NoticeBox warning>
+                {i18n.t(
+                    'There is nothing available to select. Remove a source item.'
+                )}
+            </NoticeBox>
+        )
+    }
 
     return (
         <BaseModelSingleSelect

--- a/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelect.tsx
@@ -36,7 +36,6 @@ export type ModelSingleSelectProps<
     query: Omit<PlainResourceQuery, 'id'>
     onFilterChange?: (value: string) => void
     transform?: (value: TModel[]) => TModel[]
-    noMatchWithoutFilterText?: string
 }
 
 export const ModelSingleSelect = <
@@ -45,7 +44,6 @@ export const ModelSingleSelect = <
     selected,
     query,
     transform,
-    noMatchWithoutFilterText,
     ...baseModelSingleSelectProps
 }: ModelSingleSelectProps<TModel>) => {
     const queryFn = useBoundResourceQueryFn()
@@ -157,7 +155,6 @@ export const ModelSingleSelect = <
             onEndReached={queryResult.fetchNextPage}
             loading={queryResult.isLoading}
             error={queryResult.error?.toString()}
-            noMatchWithoutFilterText={noMatchWithoutFilterText}
         />
     )
 }

--- a/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelectField.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelectField.tsx
@@ -52,6 +52,7 @@ export function ModelSingleSelectField<
     // data,
     input,
     meta,
+    noMatchWithoutFilterText,
     ...modelSingleSelectProps
 }: ModelSingleSelectFieldProps<TModel> & RelevantRenderProps<TModel>) {
     return (
@@ -73,6 +74,7 @@ export function ModelSingleSelectField<
                     onChange?.(selected)
                 }}
                 invalid={meta.touched && !!meta.error}
+                noMatchWithoutFilterText={noMatchWithoutFilterText}
             />
         </Field>
     )
@@ -87,6 +89,7 @@ export function ModelSingleSelectFormField<TModel extends DisplayableModel>({
     format,
     parse,
     data,
+    noMatchWithoutFilterText,
     ...modelSingleSelectProps
 }: ModelSingleSelectFieldProps<TModel> & RelevantUseFieldProps<TModel>) {
     const { input, meta } = useField<TModel | undefined>(name, {
@@ -102,6 +105,7 @@ export function ModelSingleSelectFormField<TModel extends DisplayableModel>({
         <ModelSingleSelectField
             input={input}
             meta={meta}
+            noMatchWithoutFilterText={noMatchWithoutFilterText}
             {...modelSingleSelectProps}
         />
     )

--- a/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelectField.tsx
+++ b/src/components/metadataFormControls/ModelSingleSelect/ModelSingleSelectField.tsx
@@ -52,7 +52,6 @@ export function ModelSingleSelectField<
     // data,
     input,
     meta,
-    noMatchWithoutFilterText,
     ...modelSingleSelectProps
 }: ModelSingleSelectFieldProps<TModel> & RelevantRenderProps<TModel>) {
     return (
@@ -74,7 +73,6 @@ export function ModelSingleSelectField<
                     onChange?.(selected)
                 }}
                 invalid={meta.touched && !!meta.error}
-                noMatchWithoutFilterText={noMatchWithoutFilterText}
             />
         </Field>
     )
@@ -89,7 +87,6 @@ export function ModelSingleSelectFormField<TModel extends DisplayableModel>({
     format,
     parse,
     data,
-    noMatchWithoutFilterText,
     ...modelSingleSelectProps
 }: ModelSingleSelectFieldProps<TModel> & RelevantUseFieldProps<TModel>) {
     const { input, meta } = useField<TModel | undefined>(name, {
@@ -105,7 +102,6 @@ export function ModelSingleSelectFormField<TModel extends DisplayableModel>({
         <ModelSingleSelectField
             input={input}
             meta={meta}
-            noMatchWithoutFilterText={noMatchWithoutFilterText}
             {...modelSingleSelectProps}
         />
     )

--- a/src/pages/categoryOptions/merge/CategoryOptionMergeFormFields.tsx
+++ b/src/pages/categoryOptions/merge/CategoryOptionMergeFormFields.tsx
@@ -54,6 +54,9 @@ export const CategoryOptionMergeFormFields = () => {
                                 fields: ['id', 'displayName', 'name'],
                             },
                         }}
+                        noMatchWithoutFilterText={i18n.t(
+                            'No category options available. Remove one from source.'
+                        )}
                     />
                 </MergeSourcesTargetWrapper>
             </FormSection>

--- a/src/pages/indicatorTypes/merge/IndicatorTypeMergeFormFields.tsx
+++ b/src/pages/indicatorTypes/merge/IndicatorTypeMergeFormFields.tsx
@@ -53,6 +53,9 @@ export const IndicatorTypeMergeFormFields = () => {
                                 fields: ['id', 'displayName', 'name', 'factor'],
                             },
                         }}
+                        noMatchWithoutFilterText={i18n.t(
+                            'No indicator types available. Remove one from source.'
+                        )}
                     />
                 </MergeSourcesTargetWrapper>
             </FormSection>

--- a/src/pages/indicators/merge/IndicatorMergeFormFields.tsx
+++ b/src/pages/indicators/merge/IndicatorMergeFormFields.tsx
@@ -48,6 +48,9 @@ export const IndicatorMergeFormFields = () => {
                                 fields: ['id', 'displayName', 'name'],
                             },
                         }}
+                        noMatchWithoutFilterText={i18n.t(
+                            'No indicators available. Remove one from source.'
+                        )}
                     />
                 </MergeSourcesTargetWrapper>
             </FormSection>


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/BETA-348

This addresses a couple of issues:

- As per the ticket's suggestion, this adds some text to make it clear that there are no selectable options when you have selected all items as source items:
![image](https://github.com/user-attachments/assets/358b40e4-2858-4d66-bdce-982e36aebcc4)

- Adds an all purpose "No matches" text when there are no matches after filtering:
![image](https://github.com/user-attachments/assets/67e5d4da-0bad-4da6-a1d3-a92c94dfce5b)

- Adds some logic in a useEffect to refresh target information until the desired pageCount of filtered results have been found (or there are no more pages left). (This fixes a bug where if you reloaded the merge page, you would get an infinite loader / not 10 initial matches for the target)