### PR TITLE
fix: sync route updates with global shell

### DIFF
--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -32,6 +32,7 @@ import {
 } from './AuthorizationGuards'
 import { DefaultErrorRoute } from './DefaultErrorRoute'
 import { LegacyAppRedirect } from './LegacyAppRedirect'
+import { SyncURLWithGlobalShell } from './SyncURLWithGlobalShell'
 import { RouteHandle } from './types'
 // This loads all the overview routes in the same chunk since they resolve to the same promise
 // see https://reactrouter.com/en/main/route/lazy#multiple-routes-in-a-single-file
@@ -220,6 +221,7 @@ const routes = createRoutesFromElements(
     <Route
         element={
             <QueryParamProvider adapter={ReactRouter6Adapter}>
+                <SyncURLWithGlobalShell />
                 <Layout />
             </QueryParamProvider>
         }

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -32,7 +32,7 @@ import {
 } from './AuthorizationGuards'
 import { DefaultErrorRoute } from './DefaultErrorRoute'
 import { LegacyAppRedirect } from './LegacyAppRedirect'
-import { SyncURLWithGlobalShell } from './SyncURLWithGlobalShell'
+import { SyncUrlWithGlobalShell } from './SyncUrlWithGlobalShell'
 import { RouteHandle } from './types'
 // This loads all the overview routes in the same chunk since they resolve to the same promise
 // see https://reactrouter.com/en/main/route/lazy#multiple-routes-in-a-single-file
@@ -221,7 +221,7 @@ const routes = createRoutesFromElements(
     <Route
         element={
             <QueryParamProvider adapter={ReactRouter6Adapter}>
-                <SyncURLWithGlobalShell />
+                <SyncUrlWithGlobalShell />
                 <Layout />
             </QueryParamProvider>
         }

--- a/src/app/routes/SyncURLWithGlobalShell.tsx
+++ b/src/app/routes/SyncURLWithGlobalShell.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+/* When the app is running in the Global Shell, the URL is not updated.
+    The Global Shell is listening to "popstate" events to update the URL.
+    However react-router@6+ does not trigger "popstate" events on pushState/replaceState.
+
+    Thus we need to listen to react-router's location changes and dispatch a "popstate" event.
+
+    Some background for react-router change: https://github.com/remix-run/react-router/blob/44472360ec9ea045008f453280bb749cb58e90ea/decisions/0005-remixing-react-router.md#inline-the-history-library-into-the-router
+
+*/
+
+export const SyncURLWithGlobalShell = ({
+    children,
+}: {
+    children?: React.ReactNode
+}) => {
+    const location = useLocation()
+
+    useEffect(() => {
+        dispatchEvent(new PopStateEvent('popstate'))
+    }, [location.key])
+
+    return children
+}

--- a/src/app/routes/SyncUrlWithGlobalShell.tsx
+++ b/src/app/routes/SyncUrlWithGlobalShell.tsx
@@ -11,7 +11,7 @@ import { useLocation } from 'react-router-dom'
 
 */
 
-export const SyncURLWithGlobalShell = ({
+export const SyncUrlWithGlobalShell = ({
     children,
 }: {
     children?: React.ReactNode


### PR DESCRIPTION
`react-router@6+` does not fire `popstate` for `pushState/replaceState`. The `global shell` [is listening](https://github.com/dhis2/global-shell-app/blob/main/src/components/PluginLoader.jsx#L45) to `popstate`-events to update the url in the parent frame. 
This PR listens to router changes from `useLocation` and creates a `popstate` event so that the global routes can update the URL in the browser. 

Previous versions of `react-router` did fire `popstate` on push/replace, there's some background of why this was changed here: https://github.com/remix-run/react-router/blob/44472360ec9ea045008f453280bb749cb58e90ea/decisions/0005-remixing-react-router.md#inline-the-history-library-into-the-router . 
