### PR TITLE
feat(forms): improve display of errors

### DIFF
--- a/src/components/form/DefaultFormErrorNotice.module.css
+++ b/src/components/form/DefaultFormErrorNotice.module.css
@@ -1,7 +1,38 @@
 .noticeBox {
     max-width: 640px;
+    overflow: auto;
+    width: 100%;
 }
 
 .errorList {
     padding: 0;
+}
+
+.errorMessage {
+    margin: 0;
+}
+
+.errorDetailsButton {
+    padding-inline-end: 8px;
+    display: block;
+}
+
+.errorDetails {
+    margin-block-start: var(--spacers-dp4);
+    position: relative;
+    background-color: var(--colors-white);
+    overflow: auto;
+    padding: var(--spacers-dp8);
+    max-height: 400px;
+    white-space: pre-wrap;
+    font-size: 12px;
+    line-height: 1.2;
+    font-family: Menlo, Courier, monospace !important;
+}
+
+.copyButton {
+    position: absolute !important;
+    inset-inline-end: 0px;
+    inset-block-start: var(--spacers-dp8);
+    margin-inline-end: var(--spacers-dp8);
 }

--- a/src/components/form/DefaultFormErrorNotice.tsx
+++ b/src/components/form/DefaultFormErrorNotice.tsx
@@ -7,9 +7,9 @@ import {
     NoticeBox,
 } from '@dhis2/ui'
 import React, { useRef } from 'react'
+import { ApiErrorReport } from '../../lib'
 import css from './DefaultFormErrorNotice.module.css'
 import { useFormStateErrors } from './useFormStateErrors'
-import { ApiErrorReport } from '../../lib'
 
 export function DefaultFormErrorNotice() {
     const formStateErrors = useFormStateErrors()

--- a/src/components/form/DefaultFormErrorNotice.tsx
+++ b/src/components/form/DefaultFormErrorNotice.tsx
@@ -1,8 +1,15 @@
 import i18n from '@dhis2/d2-i18n'
-import { NoticeBox } from '@dhis2/ui'
-import React from 'react'
+import {
+    Button,
+    IconChevronDown16,
+    IconChevronUp16,
+    IconCopy16,
+    NoticeBox,
+} from '@dhis2/ui'
+import React, { useRef } from 'react'
 import css from './DefaultFormErrorNotice.module.css'
 import { useFormStateErrors } from './useFormStateErrors'
+import { ApiErrorReport } from '../../lib'
 
 export function DefaultFormErrorNotice() {
     const formStateErrors = useFormStateErrors()
@@ -24,9 +31,9 @@ export function DefaultFormErrorNotice() {
 
     if (formStateErrors.hasSubmitErrors) {
         return (
-            <ServerSubmitErrorNotice>
-                {formStateErrors.submitError}
-            </ServerSubmitErrorNotice>
+            <ServerSubmitErrorNotice
+                errorReport={formStateErrors.submitError}
+            />
         )
     }
     return null
@@ -76,21 +83,103 @@ export const ErrorList = ({ errors }: { errors: Record<string, string> }) => {
     )
 }
 
-export const ServerSubmitErrorNotice = ({
+export const ServerSubmitErrorNoticeBox = ({
     children,
+    title = i18n.t('Something went wrong when submitting the form'),
 }: {
     children: React.ReactNode
+    title?: string
 }) => {
     return (
-        <div>
-            <NoticeBox
-                className={css.noticeBox}
-                error
-                title={i18n.t('Something went wrong when submitting the form')}
-            >
-                <p>{children}</p>
-            </NoticeBox>
-        </div>
+        <NoticeBox className={css.noticeBox} error title={title}>
+            {children}
+        </NoticeBox>
+    )
+}
+
+export const ServerSubmitErrorNotice = ({
+    errorReport,
+}: {
+    errorReport?: ApiErrorReport
+}) => {
+    const [showDetails, setShowDetails] = React.useState(false)
+    // used to scroll to the error details when the button is clicked
+    const errorDivRef = useRef<HTMLDivElement | null>(null)
+    // used to select the error details text when copy button is clicked
+    const errorPreRef = useRef<HTMLPreElement | null>(null)
+
+    if (!errorReport) {
+        return null
+    }
+
+    const handleToggleDetails = () => {
+        const newShow = !showDetails
+        setShowDetails(newShow)
+        if (newShow) {
+            // timeout because the div may not be expanded yet
+            setTimeout(
+                () =>
+                    errorDivRef.current?.scrollIntoView({
+                        block: 'start',
+                    }),
+                0
+            )
+        }
+    }
+    const handleCopyClick = () => {
+        const div = errorPreRef.current
+        if (!div) {
+            return
+        }
+        const range = document.createRange()
+        range.selectNode(div)
+        window.getSelection()?.removeAllRanges()
+        window.getSelection()?.addRange(range)
+        navigator.clipboard.writeText(verbatimError)
+    }
+
+    const verbatimError = JSON.stringify(errorReport.original, undefined, 2)
+    return (
+        <ServerSubmitErrorNoticeBox>
+            <div ref={errorDivRef}>
+                <div>
+                    <p className={css.errorMessage}>{errorReport.message}</p>
+
+                    <ul className={css.errorList}>
+                        {errorReport.errors.map((e, i) => (
+                            <li key={i}>{e.message}</li>
+                        ))}
+                    </ul>
+                </div>
+                <Button
+                    className={css.errorDetailsButton}
+                    secondary
+                    small
+                    icon={
+                        showDetails ? (
+                            <IconChevronUp16 />
+                        ) : (
+                            <IconChevronDown16 />
+                        )
+                    }
+                    onClick={handleToggleDetails}
+                >
+                    {showDetails
+                        ? i18n.t('Hide Error details')
+                        : i18n.t('Show error details')}
+                </Button>
+            </div>
+            {showDetails && (
+                <pre className={css.errorDetails} ref={errorPreRef}>
+                    <Button
+                        className={css.copyButton}
+                        onClick={handleCopyClick}
+                        icon={<IconCopy16 />}
+                    />
+                    {verbatimError}
+                </pre>
+            )}
+        </ServerSubmitErrorNoticeBox>
     )
 }
 

--- a/src/components/form/useFormStateErrors.ts
+++ b/src/components/form/useFormStateErrors.ts
@@ -1,5 +1,6 @@
 import { FormState, FormSubscription } from 'final-form'
 import { useFormState } from 'react-final-form'
+import { ApiErrorReport, ensureApiErrorReport } from '../../lib'
 
 const formStateSubscriptions = {
     errors: true,
@@ -16,11 +17,15 @@ type FinalFormErrorProps = Pick<
     keyof typeof formStateSubscriptions
 >
 
-export type FormErrorState = Omit<FinalFormErrorProps, 'errors'> & {
+export type FormErrorState = Omit<
+    FinalFormErrorProps,
+    'errors' | 'submitError'
+> & {
     // helper to decide wheter a noticebox should be shown
     shouldShowErrors: boolean
     // we rename "errors" to "validationErrors" to make it more clear that it only contain validation errors
     validationErrors: Record<string, string> | undefined
+    submitError: ApiErrorReport | undefined
 }
 
 export const useFormStateErrors = (): FormErrorState => {
@@ -43,12 +48,14 @@ export const useFormStateErrors = (): FormErrorState => {
         (hasAnyError && submitFailed && !dirtySinceLastSubmit) ||
         (submitFailed && hasSubmitErrors)
 
+    // since the error object can be anything, we need to ensure it is an ApiErrorReport
+    const apiError = ensureApiErrorReport(submitError)
     return {
         dirtySinceLastSubmit,
         hasSubmitErrors,
         hasValidationErrors,
         shouldShowErrors,
-        submitError,
+        submitError: apiError,
         submitFailed,
         validationErrors: errors,
         modifiedSinceLastSubmit,

--- a/src/components/sectionedForm/SectionedFormErrorNotice.tsx
+++ b/src/components/sectionedForm/SectionedFormErrorNotice.tsx
@@ -54,9 +54,9 @@ export function SectionedFormErrors() {
 
     if (formStateErrors.hasSubmitErrors) {
         return (
-            <ServerSubmitErrorNotice>
-                {formStateErrors.submitError}
-            </ServerSubmitErrorNotice>
+            <ServerSubmitErrorNotice
+                errorReport={formStateErrors.submitError}
+            />
         )
     }
 

--- a/src/lib/errors/apiErrorSchemas.ts
+++ b/src/lib/errors/apiErrorSchemas.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod'
+
+export const errorReportSchema = z.object({
+    args: z.array(z.string()).optional(),
+    errorCode: z.string(),
+    errorKlass: z.string().optional(),
+    errorProperties: z.array(z.any()),
+    errorProperty: z.string().optional(),
+    mainId: z.string().optional(),
+    mainKlass: z.string().optional(),
+    message: z.string().optional(),
+    value: z.any(),
+})
+export type ErrorReport = z.infer<typeof errorReportSchema>
+
+export const objectReportWebMessageResponseSchema = z
+    .object({
+        errorReports: z.array(errorReportSchema),
+        klass: z.string(),
+        responseType: z.literal('ObjectReportWebMessageResponse'),
+        uid: z.string(),
+    })
+    .strict()
+
+export const errorMessageSchema = z.object({
+    args: z.array(z.string()).optional(),
+    errorCode: z.string(),
+    message: z.string().optional(),
+})
+export type ErrorMessage = z.infer<typeof errorMessageSchema>
+
+export const mergeTypeSchema = z.enum([
+    'ORG_UNIT',
+    'INDICATOR_TYPE',
+    'INDICATOR',
+    'DATA_ELEMENT',
+])
+
+export const mergeReportSchema = z.object({
+    mergeErrors: z.array(errorMessageSchema).optional(),
+    mergeType: mergeTypeSchema,
+    message: z.string().optional(),
+    sourcesDeleted: z.array(z.string()).optional(),
+})
+
+export const mergeWebResponseSchema = z
+    .object({
+        mergeReport: mergeReportSchema.optional(),
+        responseType: z.literal('MergeWebResponse'),
+    })
+    .strict()
+
+export const statusSchema = z.enum(['OK', 'WARNING', 'ERROR'])
+export const webMessageSchema = z.object({
+    code: z.number().int().optional(),
+    devMessage: z.string().optional(),
+    errorCode: z.string().optional(),
+    httpStatus: z.string().optional(),
+    httpStatusCode: z.number().int(),
+    message: z.string().optional(),
+    response: z.union([
+        // these are all schemas from OpenAPI, however most of them
+        // are not used in maintenane app
+        objectReportWebMessageResponseSchema,
+        mergeWebResponseSchema,
+        // z.lazy(() => apiTokenCreationResponseSchema),
+        // z.lazy(() => errorReportsWebMessageResponseSchema),
+        // z.lazy(() => fileResourceWebMessageResponseSchema),
+        // z.lazy(() => flattenedDataIntegrityReportSchema),
+        // z.lazy(() => geoJsonImportReportSchema),
+        // z.lazy(() => importCountWebMessageResponseSchema),
+        // z.lazy(() => importReportWebMessageResponseSchema),
+        // z.lazy(() => importSummariesSchema),
+        // z.lazy(() => importSummarySchema),
+        // z.lazy(() => importTypeSummarySchema),
+        // z.lazy(() => jobConfigurationWebMessageResponseSchema),
+        // z.lazy(() => metadataSyncSummarySchema),
+        // z.lazy(() => predictionSummarySchema),
+        // z.lazy(() => softwareUpdateResponseSchema),
+        // z.lazy(() => trackerJobWebMessageResponseSchema),
+        // z.lazy(() => trackerJobWebMessageResponseSchema),
+    ]),
+    status: statusSchema,
+})
+
+export type Response = z.infer<typeof webMessageSchema>['response']
+
+export type ResponseType = z.infer<
+    typeof webMessageSchema
+>['response']['responseType']

--- a/src/lib/errors/apiErrors.ts
+++ b/src/lib/errors/apiErrors.ts
@@ -1,0 +1,145 @@
+import i18n from '@dhis2/d2-i18n'
+import { ErrorMessage, ErrorReport, webMessageSchema } from './apiErrorSchemas'
+import { isFetchError } from './errors'
+
+/* Discriminated union types to be able to easily get the type for the "original"-prop
+for common error-types through the errorType property */
+export type ErrorType = 'errorReport' | 'mergeReport' | 'unknown'
+export interface BaseApiError {
+    message: string
+    args: string[]
+    original: unknown
+    errorType: ErrorType
+}
+export interface UnknownError extends BaseApiError {
+    errorType: 'unknown'
+    original: unknown
+}
+export interface ErrorReportError extends BaseApiError {
+    errorType: 'errorReport'
+    original: ErrorReport
+}
+
+export interface MergeReportError extends BaseApiError {
+    errorType: 'mergeReport'
+    original: ErrorMessage
+}
+export type ApiError = ErrorReportError | MergeReportError | UnknownError
+
+// the backend have a lot of different error structures
+// so we parse them into a common structure
+export type ApiErrorReport = {
+    message: string
+    httpStatus: string
+    httpStatusCode: number
+    original: unknown
+    errors: ApiError[]
+}
+
+const createApiError = <T extends ApiError>(error: Partial<T>): T => {
+    return {
+        message: error.message || i18n.t('Unknown error'),
+        args: error.args || [],
+        original: error.original,
+        errorType: error.errorType ?? 'unknown',
+    } as T
+}
+
+const createErrorReport = (report: Partial<ApiErrorReport>): ApiErrorReport => {
+    const res = {
+        message: report.message || i18n.t('An unknown error occurred'),
+        httpStatus: report.httpStatus || i18n.t('Unknown'),
+        httpStatusCode: report.httpStatusCode || 0,
+        original: report.original || {},
+        errors: report.errors || [],
+    }
+    return res
+}
+
+const createFallbackError = (error: unknown): ApiErrorReport => {
+    let message = 'An unknown error occurred'
+    try {
+        message = (error as Error).toString()
+    } catch (e) {
+        console.error('Failed to parse error message', e)
+    }
+    return createErrorReport({
+        message,
+        original: error,
+    })
+}
+
+export const isApiErrorReport = (error: unknown): error is ApiErrorReport => {
+    if (typeof error !== 'object' || error === null) {
+        return false
+    }
+    if (
+        'message' in error &&
+        'httpStatus' in error &&
+        'httpStatusCode' in error &&
+        'original' in error &&
+        'errors' in error
+    ) {
+        return true
+    }
+    return false
+}
+
+export const ensureApiErrorReport = (
+    error: unknown
+): ApiErrorReport | undefined => {
+    if (error == undefined) {
+        return undefined
+    }
+    if (isApiErrorReport(error)) {
+        return error
+    }
+    return createFallbackError(error)
+}
+
+export const parseErrorResponse = (errorResponse: unknown): ApiErrorReport => {
+    const error = isFetchError(errorResponse)
+        ? errorResponse.details
+        : errorResponse
+    const parsed = webMessageSchema.safeParse(error)
+
+    if (parsed.success && parsed.data.response) {
+        const response = parsed.data.response
+        if ('mergeReport' in response) {
+            const errors = response?.mergeReport?.mergeErrors?.map((error) =>
+                createApiError({
+                    message: error.message,
+                    args: error.args,
+                    original: error,
+                    errorType: 'mergeReport',
+                } as const)
+            )
+            console.log({ errors })
+            return createErrorReport({
+                message: parsed.data.message,
+                httpStatus: parsed.data.httpStatus,
+                httpStatusCode: parsed.data.httpStatusCode,
+                original: parsed.data,
+                errors: errors,
+            })
+        }
+        if ('errorReports' in response) {
+            const errors = response.errorReports?.map((error) =>
+                createApiError({
+                    message: error.message,
+                    args: error.args,
+                    original: error,
+                    errorType: 'errorReport',
+                } as const)
+            )
+            return createErrorReport({
+                message: parsed.data.message,
+                httpStatus: parsed.data.httpStatus,
+                httpStatusCode: parsed.data.httpStatusCode,
+                original: parsed.data,
+                errors: errors,
+            })
+        }
+    }
+    return createFallbackError(error)
+}

--- a/src/lib/errors/apiErrors.ts
+++ b/src/lib/errors/apiErrors.ts
@@ -119,7 +119,7 @@ export const parseErrorResponse = (errorResponse: unknown): ApiErrorReport => {
                     errorType: 'mergeReport',
                 } as const)
             )
-            console.log({ errors })
+
             return createErrorReport({
                 message: parsed.data.message,
                 httpStatus: parsed.data.httpStatus,

--- a/src/lib/errors/apiErrors.ts
+++ b/src/lib/errors/apiErrors.ts
@@ -59,10 +59,11 @@ const createErrorReport = (report: Partial<ApiErrorReport>): ApiErrorReport => {
 const createFallbackError = (error: unknown): ApiErrorReport => {
     let message = 'An unknown error occurred'
     try {
-        message = (error as Error).toString()
+        message = (error as Error).message
     } catch (e) {
         console.error('Failed to parse error message', e)
     }
+
     return createErrorReport({
         message,
         original: error,
@@ -85,6 +86,10 @@ export const isApiErrorReport = (error: unknown): error is ApiErrorReport => {
     return false
 }
 
+/**
+ * Ensure that error is of type ApiErrorReport
+ * If not, create a fallback error of type ApiErrorReport
+ */
 export const ensureApiErrorReport = (
     error: unknown
 ): ApiErrorReport | undefined => {

--- a/src/lib/errors/errors.ts
+++ b/src/lib/errors/errors.ts
@@ -1,3 +1,9 @@
+import { FetchError } from '@dhis2/app-runtime'
+
+export const isFetchError = (error: unknown): error is FetchError => {
+    return error instanceof FetchError
+}
+
 export type ModuleNotFoundError = Error & {
     code: 'MODULE_NOT_FOUND'
 }

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,1 +1,2 @@
 export * from './errors'
+export * from './apiErrors'

--- a/src/lib/form/createFormError.ts
+++ b/src/lib/form/createFormError.ts
@@ -1,11 +1,16 @@
 import { FORM_ERROR } from 'final-form'
+import { ApiErrorReport, isApiErrorReport, parseErrorResponse } from '../errors'
 
-export const createFormError = (error: unknown) => {
-    let errorMessage
-    if (error instanceof Error || typeof error === 'string') {
-        errorMessage = error.toString()
+export const createFormError = (
+    error: unknown
+): {
+    [FORM_ERROR]: ApiErrorReport
+} => {
+    let resolvedError: ApiErrorReport
+    if (isApiErrorReport(error)) {
+        resolvedError = error
     } else {
-        errorMessage = 'An unknown error occurred'
+        resolvedError = parseErrorResponse(error)
     }
-    return { [FORM_ERROR]: errorMessage }
+    return { [FORM_ERROR]: resolvedError }
 }

--- a/src/lib/form/useCreateModel.ts
+++ b/src/lib/form/useCreateModel.ts
@@ -1,6 +1,6 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import { FORM_ERROR } from 'final-form'
 import { useCallback } from 'react'
+import { parseErrorResponse } from '../errors'
 
 export const useCreateModel = (resource: string) => {
     const dataEngine = useDataEngine()
@@ -13,9 +13,9 @@ export const useCreateModel = (resource: string) => {
                     type: 'create',
                     data: data,
                 })
-                return { response }
+                return { data: response }
             } catch (error) {
-                return { [FORM_ERROR]: (error as Error | string).toString() }
+                return { error: parseErrorResponse(error) }
             }
         },
         [dataEngine, resource]

--- a/src/lib/form/usePatchModel.ts
+++ b/src/lib/form/usePatchModel.ts
@@ -1,7 +1,7 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import { FORM_ERROR } from 'final-form'
 import { useCallback, useState } from 'react'
 import { JsonPatchOperation } from '../../types'
+import { parseErrorResponse } from '../errors'
 
 const createPatchQuery = (id: string, resource: string) => {
     return {
@@ -19,11 +19,12 @@ export const usePatchModel = (id: string, resource: string) => {
     const patch = useCallback(
         async (operations: JsonPatchOperation[]) => {
             try {
-                await dataEngine.mutate(query, {
+                const response = await dataEngine.mutate(query, {
                     variables: { operations },
                 })
+                return { data: response }
             } catch (error) {
-                return { [FORM_ERROR]: (error as Error | string).toString() }
+                return { error: parseErrorResponse(error) }
             }
         },
         [dataEngine, query]

--- a/src/pages/organisationUnits/Edit.tsx
+++ b/src/pages/organisationUnits/Edit.tsx
@@ -13,6 +13,7 @@ import {
     useNavigateWithSearchState,
     usePatchModel,
 } from '../../lib'
+import { createFormError } from '../../lib/form/createFormError'
 import { createJsonPatchOperations } from '../../lib/form/createJsonPatchOperations'
 import { useBoundResourceQueryFn } from '../../lib/query/useBoundQueryFn'
 import { OrganisationUnit, PickWithFieldFilters } from '../../types/generated'
@@ -93,11 +94,11 @@ export const useOnEditOrgUnits = (modelId: string) => {
                     return
                 }
 
-                const orgUnitErrors = await patchDirtyFields(
+                const { error } = await patchDirtyFields(
                     orgUnitJsonPatchOperations
                 )
-                if (orgUnitErrors) {
-                    return orgUnitErrors
+                if (error) {
+                    return createFormError(error)
                 }
 
                 await updateDataSetsAndPrograms(modelId, values)
@@ -107,7 +108,14 @@ export const useOnEditOrgUnits = (modelId: string) => {
                 })
                 navigate(`/${getSectionPath(section)}`)
             },
-        [patchDirtyFields, saveAlert, navigate, section]
+        [
+            patchDirtyFields,
+            saveAlert,
+            navigate,
+            modelId,
+            queryClient,
+            updateDataSetsAndPrograms,
+        ]
     )
 }
 


### PR DESCRIPTION
Implements https://dhis2.atlassian.net/browse/DHIS2-18984 

Refactor error-handling, and stores the full error in the form-state instead of just a string of the error on the root of the server error.
Implemented an unified "error"-type `ApiErrorReport`, since the backend has multiple error-structures. We parse the different structure into this unified type, so it's easier for the client to consume the error. Currently the parsing is implemented using `zod`-schemas, these schemas are generated using [kubb](https://kubb.dev/) and openAPI. The relevant schemas has been manually copied, but we may want to use the same tool to generate and publish types and `zod`-schemas later. This work is related to the openAPI type-generation that I worked on before christmas that was postponed. 

There was no design for the error-noticebox, so I taken creative freedom here - but kept it pretty simple. I wanted a way to show the "verbatim"-error, so it's possible to expand and easily copy the full error from the backend. 

<img width="714" alt="image" src="https://github.com/user-attachments/assets/35a51b32-1c0f-4878-824f-9a01d068c439" />

