### PR TITLE
fix: hide other section

### DIFF
--- a/src/app/sidebar/SidebarLinks.ts
+++ b/src/app/sidebar/SidebarLinks.ts
@@ -107,10 +107,10 @@ export const sidebarLinks = {
             getSectionLinkItem(SECTIONS_MAP.validationNotificationTemplate),
         ],
     },
-    other: {
-        label: OVERVIEW_SECTIONS.other.title,
-        links: [getSectionLinkItem(SECTIONS_MAP.programDisaggregation)],
-    },
+    // other: {
+    //     label: OVERVIEW_SECTIONS.other.title,
+    //     links: [getSectionLinkItem(SECTIONS_MAP.programDisaggregation)],
+    // },
 } satisfies SidebarLinks
 
 export const useSidebarLinks = (): ParentLink[] => {


### PR DESCRIPTION
Hides the 'other' section (including program disaggregations) in sidebar while this is work in progress.

**Before**
<img width="584" alt="image" src="https://github.com/user-attachments/assets/48bef69b-5379-4b8f-a1ed-bea4f12595c3" />

**After**
<img width="479" alt="image" src="https://github.com/user-attachments/assets/14a408f5-7204-4246-8a73-a49c2d673e40" />
