### PR TITLE
feat: add aggregateExportDataElement [DHIS2-19334]

### DIFF
--- a/src/pages/programDisaggregations/Edit.tsx
+++ b/src/pages/programDisaggregations/Edit.tsx
@@ -51,6 +51,7 @@ const programIndicatorFieldFilters = [
     'categoryMappingIds',
     'attributeCombo[id, displayName, dataDimensionType, categories[id, displayName]]',
     'categoryCombo[id, displayName, dataDimensionType, categories[id, displayName]]',
+    'aggregateExportDataElement',
 ] as const
 
 export type ProgramData = PickWithFieldFilters<Program, typeof fieldFilters>

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMapping.module.css
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMapping.module.css
@@ -10,6 +10,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacers-dp8);
+    margin-block-end: var(--spacers-dp16);
 }
 
 .mappingFields {

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
@@ -1,7 +1,12 @@
 import i18n from '@dhis2/d2-i18n'
-import { Button, SingleSelectField, SingleSelectOption } from '@dhis2/ui'
+import {
+    Button,
+    InputFieldFF,
+    SingleSelectField,
+    SingleSelectOption,
+} from '@dhis2/ui'
 import React, { useEffect, useMemo } from 'react'
-import { useField } from 'react-final-form'
+import { Field, useField } from 'react-final-form'
 import { useParams } from 'react-router-dom'
 import {
     CollapsibleCard,
@@ -9,6 +14,7 @@ import {
     CollapsibleCardTitle,
     SectionedFormSection,
     StandardFormSectionTitle,
+    StandardFormField,
 } from '../../../components'
 import {
     ModelSingleSelect,
@@ -153,6 +159,14 @@ export const ProgramIndicatorMapping = ({
                     )
                 )}
             </div>
+            <StandardFormField>
+                <Field
+                    name={`programIndicatorMappings.${programIndicator.id}.aggregateExportDataElement`}
+                    key={`programIndicatorMappings.${programIndicator.id}.aggregateExportDataElement`}
+                    label={i18n.t('Data element for aggregate data export')}
+                    component={InputFieldFF}
+                />
+            </StandardFormField>
         </div>
     )
 }

--- a/src/pages/programDisaggregations/form/programDisaggregationSchema.ts
+++ b/src/pages/programDisaggregations/form/programDisaggregationSchema.ts
@@ -41,6 +41,7 @@ export const programIndicatorSchema = z.object({
             ),
         })
         .optional(),
+    aggregateExportDataElement: z.string().optional(),
     // map from categoryId to categoryMapping
     disaggregation: z.record(z.string(), z.string()),
     attribute: z.record(z.string(), z.string()),

--- a/src/pages/programDisaggregations/form/useUpdateProgramIndicatorMutation.ts
+++ b/src/pages/programDisaggregations/form/useUpdateProgramIndicatorMutation.ts
@@ -35,7 +35,7 @@ export const useUpdateProgramIndicatorMutation = () => {
                       )
                     : []
             const newAggregateExportDataElement =
-                programIndicatorMapping?.aggregateExportDataElement
+                programIndicatorMapping?.aggregateExportDataElement ?? null
 
             const patchOperations = {
                 type: 'json-patch',

--- a/src/pages/programDisaggregations/form/useUpdateProgramIndicatorMutation.ts
+++ b/src/pages/programDisaggregations/form/useUpdateProgramIndicatorMutation.ts
@@ -34,6 +34,8 @@ export const useUpdateProgramIndicatorMutation = () => {
                               ]
                       )
                     : []
+            const newAggregateExportDataElement =
+                programIndicatorMapping?.aggregateExportDataElement
 
             const patchOperations = {
                 type: 'json-patch',
@@ -49,6 +51,11 @@ export const useUpdateProgramIndicatorMutation = () => {
                         op: 'replace',
                         path: '/categoryMappingIds',
                         value: newCategoryMappingsIds,
+                    },
+                    {
+                        op: 'replace',
+                        path: '/aggregateExportDataElement',
+                        value: newAggregateExportDataElement,
                     },
                 ],
             } as const


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-19334

This PR adds the `aggregateExportDataElement` field as per the specs' prototype. There is no validation on the field per design and user is free to enter anything (e.g. because they may be using code for the export on an external system).

![image](https://github.com/user-attachments/assets/ab97fb26-36fd-408f-b027-98effffe3801)
