### PR TITLE
feat: sort initial category mappings [DHIS2-19246]

### DIFF
--- a/src/pages/programDisaggregations/form/DissaggregationCategories.tsx
+++ b/src/pages/programDisaggregations/form/DissaggregationCategories.tsx
@@ -341,6 +341,9 @@ export const DisaggregationCategory = ({
     initiallyExpanded = false,
 }: DisaggregationCategoryProps) => {
     const array = useFieldArray(`categoryMappings.${id}`)
+    const showSoftDelete =
+        array.fields.value.filter((val) => !val.deleted).length > 1
+
     const { input: categoryMappingsDeleted } = useField(
         'categoryMappings.deleted'
     )
@@ -399,14 +402,14 @@ export const DisaggregationCategory = ({
                 </CollapsibleCardHeader>
             }
         >
-            {array.fields.map((fieldName, index) => (
+            {array.fields.map((fieldName) => (
                 <div key={fieldName}>
                     <CategoryMapping
                         fieldName={fieldName}
                         categoryOptionArray={
                             categoryObject?.[id]?.categoryOptions ?? []
                         }
-                        showSoftDelete={index !== 0}
+                        showSoftDelete={showSoftDelete}
                     />
                 </div>
             ))}

--- a/src/pages/programDisaggregations/form/apiResponseToFormValues.ts
+++ b/src/pages/programDisaggregations/form/apiResponseToFormValues.ts
@@ -47,6 +47,11 @@ export const apiResponseToFormValues = ({
         ]
         return acc
     }, {} as CategoryMappingsRecord)
+    for (const cat in categoryMappings) {
+        categoryMappings[cat].sort((a, b) =>
+            a.mappingName.localeCompare(b.mappingName)
+        )
+    }
 
     const programIndicatorMappings = programIndicators.programIndicators.reduce(
         (acc, indicator) => {


### PR DESCRIPTION
This PR is a follow up to discussion yesterday on how to handle UI given that the backend does not necessarily return categoryMappings in a fixed order.

- sorts the category mappings in the initial values alphabetically by mapping name
- presents the soft delete option for individual mapping when there are two or more non-soft deleted category mappings for a given category