### PR TITLE
fix: fix crash when adding a suggested category combo

### DIFF
--- a/src/pages/programDisaggregations/form/CategoriesSelector.tsx
+++ b/src/pages/programDisaggregations/form/CategoriesSelector.tsx
@@ -14,7 +14,7 @@ export const categoriesFieldFilter = [
     'dataDimensionType',
     'categoryOptions[id,displayName]',
 ] as const
-const categoryComboFieldFilter = [
+export const categoryComboFieldFilter = [
     'id',
     'displayName',
     'dataDimensionType',

--- a/src/pages/programDisaggregations/form/CategoryMapping.tsx
+++ b/src/pages/programDisaggregations/form/CategoryMapping.tsx
@@ -220,7 +220,7 @@ const CategoryMappingInput = ({
                 validationText={
                     validation.input.value && i18n.t('Invalid expression')
                 }
-                warning={validation.input.value}
+                warning={!!validation.input.value}
             />
         </div>
     )

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
@@ -22,6 +22,10 @@ import {
 } from '../../../components/metadataFormControls/ModelSingleSelect'
 import { DisplayableModel } from '../../../types/models'
 import { ProgramIndicatorWithMapping } from '../Edit'
+import {
+    categoryComboFieldFilter,
+    CategoryComboFromSelect,
+} from './CategoriesSelector'
 import { CategoryMapping } from './programDisaggregationSchema'
 import css from './ProgramIndicatorMapping.module.css'
 
@@ -175,17 +179,13 @@ export const ProgramIndicatorMapping = ({
     return (
         <div className={css.mappingFields}>
             <div>
-                <ModelSingleSelectField
+                <ModelSingleSelectField<CategoryComboFromSelect>
                     label="Disaggregation category combination"
                     query={{
                         resource: 'categoryCombos',
                         params: {
                             filter: 'dataDimensionType:eq:DISAGGREGATION',
-                            fields: [
-                                'id',
-                                'displayName',
-                                'categories[id,displayName,dataDimensionType,categoryOptions[id,displayName]]',
-                            ],
+                            fields: categoryComboFieldFilter.concat(),
                         },
                     }}
                     showNoValueOption
@@ -217,17 +217,13 @@ export const ProgramIndicatorMapping = ({
                 </div>
             </div>
             <div>
-                <ModelSingleSelectField
+                <ModelSingleSelectField<CategoryComboFromSelect>
                     label={i18n.t('Attribute category combination')}
                     query={{
                         resource: 'categoryCombos',
                         params: {
                             filter: 'dataDimensionType:eq:ATTRIBUTE',
-                            fields: [
-                                'id',
-                                'displayName',
-                                'categories[id,displayName,dataDimensionType,categoryOptions[id,displayName]]',
-                            ],
+                            fields: categoryComboFieldFilter.concat(),
                         },
                     }}
                     showNoValueOption

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
@@ -184,7 +184,7 @@ export const ProgramIndicatorMapping = ({
                             fields: [
                                 'id',
                                 'displayName',
-                                'categories[id,displayName]',
+                                'categories[id,displayName,dataDimensionType,categoryOptions[id,displayName]]',
                             ],
                         },
                     }}
@@ -226,7 +226,7 @@ export const ProgramIndicatorMapping = ({
                             fields: [
                                 'id',
                                 'displayName',
-                                'categories[id,displayName]',
+                                'categories[id,displayName,dataDimensionType,categoryOptions[id,displayName]]',
                             ],
                         },
                     }}


### PR DESCRIPTION
There was a mismatch between the field-filters for the `categoryCombo` selectors, and we thus had missing information when selecting a new catcombo, compared to loading the form-state. There were actually two bugs; one due to missing categoryOptions - so the options were not in the state after selecting. And one with missing `dataDimensionType` - so the option was filtered out in `calculatedCategories`. 