### PR TITLE
fix: pi disaggregations clean up [DHIS2-19651]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-05-01T11:46:33.437Z\n"
-"PO-Revision-Date: 2025-05-01T11:46:33.437Z\n"
+"POT-Creation-Date: 2025-05-27T08:54:45.073Z\n"
+"PO-Revision-Date: 2025-05-27T08:54:45.073Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -99,9 +99,6 @@ msgstr "Required"
 msgid "Please enter a GeoJSON value"
 msgstr "Please enter a GeoJSON value"
 
-msgid "Save and close"
-msgstr "Save and close"
-
 msgid "Exit without saving"
 msgstr "Exit without saving"
 
@@ -122,6 +119,9 @@ msgstr "Hide error details"
 
 msgid "Show error details"
 msgstr "Show error details"
+
+msgid "Save and close"
+msgstr "Save and close"
 
 msgid "<No value>"
 msgstr "<No value>"
@@ -210,6 +210,11 @@ msgstr "Correct confirmation code must be entered to merge"
 
 msgid "Merge"
 msgstr "Merge"
+
+msgid "Merging {{count}} {{model}}..."
+msgid_plural "Merging {{count}} {{model}}..."
+msgstr[0] "Merging {{count}} {{model}}..."
+msgstr[1] "Merging {{count}} {{model}}..."
 
 msgid "Merging..."
 msgstr "Merging..."
@@ -525,15 +530,6 @@ msgstr "Translation updated successfully"
 
 msgid "Save translations"
 msgstr "Save translations"
-
-msgid "Go back"
-msgstr "Go back"
-
-msgid "Next section"
-msgstr "Next section"
-
-msgid "Save and exit"
-msgstr "Save and exit"
 
 msgid "Can edit and capture"
 msgstr "Can edit and capture"
@@ -1174,6 +1170,11 @@ msgstr "Filter available categories"
 msgid "Filter selected categories"
 msgstr "Filter selected categories"
 
+msgid "{{count}} category option combinations will be generated."
+msgid_plural "{{count}} category option combinations will be generated."
+msgstr[0] "{{count}} category option combinations will be generated."
+msgstr[1] "{{count}} category option combinations will be generated."
+
 msgid "More than 4 Categories"
 msgstr "More than 4 Categories"
 
@@ -1344,6 +1345,16 @@ msgid ""
 msgstr ""
 "What should happen to the source category options after the merge is "
 "complete?"
+
+msgid "Keep {{ count }} source category options"
+msgid_plural "Keep {{ count }} source category options"
+msgstr[0] "Keep {{ count }} source category options"
+msgstr[1] "Keep {{ count }} source category options"
+
+msgid "Delete {{ count }} source category options"
+msgid_plural "Delete {{ count }} source category options"
+msgstr[0] "Delete {{ count }} source category options"
+msgstr[1] "Delete {{ count }} source category options"
 
 msgid "Custom attributes"
 msgstr "Custom attributes"
@@ -1836,6 +1847,16 @@ msgstr ""
 "What should happen to the source indicator types after the merge is "
 "complete?"
 
+msgid "Keep {{ count }} source indicator types"
+msgid_plural "Keep {{ count }} source indicator types"
+msgstr[0] "Keep {{ count }} source indicator types"
+msgstr[1] "Keep {{ count }} source indicator types"
+
+msgid "Delete {{ count }} source indicator types"
+msgid_plural "Delete {{ count }} source indicator types"
+msgstr[0] "Delete {{ count }} source indicator types"
+msgstr[1] "Delete {{ count }} source indicator types"
+
 msgid "Conflicting factors"
 msgstr "Conflicting factors"
 
@@ -1886,6 +1907,16 @@ msgstr "No indicators available. Remove one from source."
 
 msgid "What should happen to the source indicators after the merge is complete?"
 msgstr "What should happen to the source indicators after the merge is complete?"
+
+msgid "Keep {{ count }} source indicators"
+msgid_plural "Keep {{ count }} source indicators"
+msgstr[0] "Keep {{ count }} source indicators"
+msgstr[1] "Keep {{ count }} source indicators"
+
+msgid "Delete {{ count }} source indicators"
+msgid_plural "Delete {{ count }} source indicators"
+msgstr[0] "Delete {{ count }} source indicators"
+msgstr[1] "Delete {{ count }} source indicators"
 
 msgid "Set up the basic information for this organisational unit group set."
 msgstr "Set up the basic information for this organisational unit group set."
@@ -2212,11 +2243,11 @@ msgstr "Rename category mapping"
 msgid "Apply"
 msgstr "Apply"
 
-msgid "{{- categoryMappingName}} mapping will be deleted on save"
-msgstr "{{- categoryMappingName}} mapping will be deleted on save"
+msgid "{{- categoryMappingName}} mapping will be removed on save"
+msgstr "{{- categoryMappingName}} mapping will be removed on save"
 
-msgid "Undo delete"
-msgstr "Undo delete"
+msgid "Restore mapping"
+msgstr "Restore mapping"
 
 msgid "Mapping: "
 msgstr "Mapping: "
@@ -2246,11 +2277,14 @@ msgstr "Suggested based on Program Indicator selections"
 msgid "Add category"
 msgstr "Add category"
 
-msgid "{{- categoryName}} and all mappings will be deleted on save"
-msgstr "{{- categoryName}} and all mappings will be deleted on save"
+msgid "All mappings for {{- categoryName}} will be removed on save"
+msgstr "All mappings for {{- categoryName}} will be removed on save"
 
-msgid "Remove category"
-msgstr "Remove category"
+msgid "Restore mappings"
+msgstr "Restore mappings"
+
+msgid "Remove category mappings"
+msgstr "Remove category mappings"
 
 msgid "Add mapping"
 msgstr "Add mapping"
@@ -2260,6 +2294,9 @@ msgstr "Program Indicator mapping"
 
 msgid "Add a program indicator"
 msgstr "Add a program indicator"
+
+msgid "All mappings for {{- programIndicator}} will be removed on save"
+msgstr "All mappings for {{- programIndicator}} will be removed on save"
 
 msgid "Program Indicator:"
 msgstr "Program Indicator:"
@@ -2303,6 +2340,11 @@ msgstr "Delete Mapping"
 msgid "This action cannot be undone."
 msgstr "This action cannot be undone."
 
+msgid "All mappings ({{count}}) will be removed."
+msgid_plural "All mappings ({{count}}) will be removed."
+msgstr[0] "All mappings ({{count}}) will be removed."
+msgstr[1] "All mappings ({{count}}) will be removed."
+
 msgid "Are you sure you want to delete this program mapping configuration?"
 msgstr "Are you sure you want to delete this program mapping configuration?"
 
@@ -2317,11 +2359,3 @@ msgstr "program_indicator_mappings"
 msgctxt "mappings"
 msgid "disaggregation_category"
 msgstr "disaggregation_category_mappings"
-
-msgctxt "Application title"
-msgid "__MANIFEST_APP_TITLE"
-msgstr "Maintenance (Preview)"
-
-msgctxt "Application description"
-msgid "__MANIFEST_APP_DESCRIPTION"
-msgstr ""

--- a/src/pages/programDisaggregations/Edit.tsx
+++ b/src/pages/programDisaggregations/Edit.tsx
@@ -39,8 +39,8 @@ const programIndicatorFieldFilters = [
     'name',
     'displayName',
     'categoryMappingIds',
-    'attributeCombo[id, displayName, dataDimensionType, categories[id, displayName,name,dataDimensionType,categoryOptions[id, displayName]]]',
-    'categoryCombo[id, displayName, dataDimensionType, categories[id, displayName,name,dataDimensionType,categoryOptions[id, displayName]]]',
+    'attributeCombo[id, displayName, name, dataDimensionType, categories[id, displayName,name,dataDimensionType,categoryOptions[id, displayName]]]',
+    'categoryCombo[id, displayName, name, dataDimensionType, categories[id, displayName,name,dataDimensionType,categoryOptions[id, displayName]]]',
     'aggregateExportDataElement',
 ] as const
 

--- a/src/pages/programDisaggregations/Edit.tsx
+++ b/src/pages/programDisaggregations/Edit.tsx
@@ -39,8 +39,8 @@ const programIndicatorFieldFilters = [
     'name',
     'displayName',
     'categoryMappingIds',
-    'attributeCombo[id, displayName, dataDimensionType, categories[id, displayName,dataDimensionType,categoryOptions[id, displayName]]]',
-    'categoryCombo[id, displayName, dataDimensionType, categories[id, displayName,dataDimensionType,categoryOptions[id, displayName]]]',
+    'attributeCombo[id, displayName, dataDimensionType, categories[id, displayName,name,dataDimensionType,categoryOptions[id, displayName]]]',
+    'categoryCombo[id, displayName, dataDimensionType, categories[id, displayName,name,dataDimensionType,categoryOptions[id, displayName]]]',
     'aggregateExportDataElement',
 ] as const
 

--- a/src/pages/programDisaggregations/Edit.tsx
+++ b/src/pages/programDisaggregations/Edit.tsx
@@ -209,6 +209,9 @@ export const Component = () => {
                                             initialProgramIndicators={
                                                 initialProgramIndicators
                                             }
+                                            programName={
+                                                programQuery?.data?.displayName
+                                            }
                                         />
                                         <DefaultFormFooter />
                                     </form>

--- a/src/pages/programDisaggregations/Edit.tsx
+++ b/src/pages/programDisaggregations/Edit.tsx
@@ -75,7 +75,7 @@ export const Component = () => {
                 resource: 'programIndicators',
                 params: {
                     fields: programIndicatorFieldFilters.concat(),
-                    filter: [`program.id:eq:${id}`, 'categoryMappingIds:gt:0'],
+                    filter: [`program.id:eq:${id}`],
                     pageSize: 200,
                 },
             },

--- a/src/pages/programDisaggregations/List.spec.tsx
+++ b/src/pages/programDisaggregations/List.spec.tsx
@@ -13,10 +13,7 @@ import type { Program } from '../../types/generated'
 import { Component as ProgramIndicators } from './List'
 
 const deleteOrgUnitMock = jest.fn()
-const renderList = async ({
-    programs = [] as Partial<Program>[],
-    programsWithMappings = [] as Partial<Program>[],
-}) => {
+const renderList = async ({ programs = [] as Partial<Program>[] }) => {
     const routeOptions = {
         handle: { section: SECTIONS_MAP.programDisaggregation },
     }
@@ -27,14 +24,20 @@ const renderList = async ({
             customData={{
                 programs: (type: any, params: any) => {
                     if (type === 'read') {
-                        return { programs }
+                        const programsWithCategoryMappingsSize = programs.map(
+                            (p) => ({
+                                ...p,
+                                categoryMappings:
+                                    p.categoryMappings?.length || 0,
+                            })
+                        )
+                        return { programs: programsWithCategoryMappingsSize }
                     }
                     if (type === 'json-patch') {
                         deleteOrgUnitMock(params)
                         return { statusCode: 204 }
                     }
                 },
-                'programs/gist': () => ({ programs: programsWithMappings }),
             }}
             routeOptions={routeOptions}
         >
@@ -58,7 +61,7 @@ describe('Program Indicators list', () => {
             categoryMappings: [testCategoryMapping()],
         })
         const screen = await renderList({
-            programsWithMappings: [programsWithMapping1, programsWithMapping2],
+            programs: [programsWithMapping1, programsWithMapping2],
         })
         const listPrograms = screen.getAllByTestId('program-with-mapping')
         expect(listPrograms).toHaveLength(2)
@@ -72,7 +75,7 @@ describe('Program Indicators list', () => {
 
     it('should show a message if there is no programs with mappings', async () => {
         const screen = await renderList({
-            programsWithMappings: [],
+            programs: [],
         })
         const noProgramsMessage = screen.getByTestId(
             'no-programs-with-mappings'
@@ -85,7 +88,7 @@ describe('Program Indicators list', () => {
             categoryMappings: [testCategoryMapping()],
         })
         const screen = await renderList({
-            programsWithMappings: [programsWithMapping],
+            programs: [programsWithMapping],
         })
         const listProgram = screen.getByTestId('program-with-mapping')
         const editButton = within(listProgram).getByTestId('link-button')
@@ -101,7 +104,7 @@ describe('Program Indicators list', () => {
             categoryMappings: [testCategoryMapping()],
         })
         const screen = await renderList({
-            programsWithMappings: [programsWithMapping],
+            programs: [programsWithMapping],
         })
         const listProgram = screen.getByTestId('program-with-mapping')
         const deleteButton = within(listProgram).getByTestId(
@@ -140,7 +143,7 @@ describe('Program Indicators list', () => {
             categoryMappings: [testCategoryMapping()],
         })
         const screen = await renderList({
-            programsWithMappings: [programsWithMapping],
+            programs: [programsWithMapping],
         })
         const listProgram = screen.getByTestId('program-with-mapping')
         const deleteButton = within(listProgram).getByTestId(

--- a/src/pages/programDisaggregations/form/CategoriesSelector.tsx
+++ b/src/pages/programDisaggregations/form/CategoriesSelector.tsx
@@ -11,6 +11,7 @@ import css from './CategoriesSelector.module.css'
 export const categoriesFieldFilter = [
     'id',
     'displayName',
+    'name',
     'dataDimensionType',
     'categoryOptions[id,displayName]',
 ] as const
@@ -18,7 +19,7 @@ export const categoryComboFieldFilter = [
     'id',
     'displayName',
     'dataDimensionType',
-    'categories[id,displayName,dataDimensionType,categoryOptions[id,displayName]]',
+    'categories[id,displayName,name,dataDimensionType,categoryOptions[id,displayName]]',
 ] as const
 export type CategoryComboFromSelect = PickWithFieldFilters<
     CategoryCombo,

--- a/src/pages/programDisaggregations/form/CategoryMapping.tsx
+++ b/src/pages/programDisaggregations/form/CategoryMapping.tsx
@@ -114,7 +114,7 @@ export const CategoryMapping = React.memo(function CategoryMapping({
             <CategoryMappingWrapper deleted>
                 <div className={css.deletedMappingText}>
                     {i18n.t(
-                        '{{- categoryMappingName}} mapping will be deleted on save',
+                        '{{- categoryMappingName}} mapping will be removed on save',
                         {
                             categoryMappingName:
                                 categoryMappingValue.mappingName,
@@ -130,7 +130,7 @@ export const CategoryMapping = React.memo(function CategoryMapping({
                         })
                     }}
                 >
-                    {i18n.t('Undo delete')}
+                    {i18n.t('Restore mapping')}
                 </Button>
             </CategoryMappingWrapper>
         )

--- a/src/pages/programDisaggregations/form/CategoryMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/CategoryMappingSection.tsx
@@ -334,7 +334,7 @@ export const CategoryMappingList = ({
             <div className={css.categoryCardDeleted}>
                 <div className={css.deletedCategoryText}>
                     {i18n.t(
-                        '{{- categoryName}} and all mappings will be deleted on save',
+                        'All mappings for {{- categoryName}} will be removed on save',
                         { categoryName: categoryDisplayName }
                     )}
                 </div>
@@ -349,7 +349,7 @@ export const CategoryMappingList = ({
                         )
                     }}
                 >
-                    {i18n.t('Undo delete')}
+                    {i18n.t('Restore mappings')}
                 </Button>
             </div>
         )
@@ -381,7 +381,7 @@ export const CategoryMappingList = ({
                             ])
                         }}
                     >
-                        {i18n.t('Remove category')}
+                        {i18n.t('Remove category mappings')}
                     </Button>
                 </CollapsibleCardHeader>
             }

--- a/src/pages/programDisaggregations/form/CategoryMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/CategoryMappingSection.tsx
@@ -52,7 +52,7 @@ const createNewOptionMapping = (
 ) => ({
     categoryId: category.id,
     id: generateDhis2Id(),
-    mappingName: name ?? 'Standard mapping',
+    mappingName: name ?? `Standard ${category.name} mapping`,
     options: getEmptyOptionValues(category.categoryOptions),
     deleted: false,
     category,

--- a/src/pages/programDisaggregations/form/ProgramDisaggregationFormFields.tsx
+++ b/src/pages/programDisaggregations/form/ProgramDisaggregationFormFields.tsx
@@ -11,14 +11,17 @@ import { ProgramIndicatorMappingSection } from './ProgramIndicatorMappingSection
 
 export const ProgramDisaggregationFormFields = ({
     initialProgramIndicators,
+    programName,
 }: {
     initialProgramIndicators: ProgramIndicatorWithMapping[]
+    programName?: string
 }) => {
     return (
         <div>
             <SectionedFormSections>
                 <ProgramIndicatorMappingSection
                     initialProgramIndicators={initialProgramIndicators}
+                    programName={programName}
                 />
                 <SectionedFormSection name="disaggregationCategories">
                     <StandardFormSectionTitle>

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMapping.module.css
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMapping.module.css
@@ -55,3 +55,9 @@
     font-size: 15px;
     margin-block-end: var(--spacers-dp8);
 }
+
+.programName {
+    margin-block-end: var(--spacers-dp8);
+    color: var(--colors-grey700);
+    font-size: 15px;
+}

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
@@ -189,7 +189,10 @@ export const ProgramIndicatorMapping = ({
                     query={{
                         resource: 'categoryCombos',
                         params: {
-                            filter: 'dataDimensionType:eq:DISAGGREGATION',
+                            filters: [
+                                'dataDimensionType:eq:DISAGGREGATION',
+                                'name:neq:default',
+                            ],
                             fields: categoryComboFieldFilter.concat(),
                         },
                     }}
@@ -227,7 +230,10 @@ export const ProgramIndicatorMapping = ({
                     query={{
                         resource: 'categoryCombos',
                         params: {
-                            filter: 'dataDimensionType:eq:ATTRIBUTE',
+                            filters: [
+                                'dataDimensionType:eq:ATTRIBUTE',
+                                'name:neq:default',
+                            ],
                             fields: categoryComboFieldFilter.concat(),
                         },
                     }}

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
@@ -115,7 +115,7 @@ const ProgramIndicatorCard = ({
             <div className={css.programIndicatorCardDeleted}>
                 <div className={css.deletedProgramIndicatorText}>
                     {i18n.t(
-                        '{{- programIndicator}} and all mappings will be deleted on save',
+                        'All mappings for {{- programIndicator}} will be removed on save',
                         { programIndicator: programIndicator.displayName }
                     )}
                 </div>
@@ -131,7 +131,7 @@ const ProgramIndicatorCard = ({
                         )
                     }}
                 >
-                    {i18n.t('Undo delete')}
+                    {i18n.t('Restore mappings')}
                 </Button>
             </div>
         )

--- a/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/ProgramIndicatorMappingSection.tsx
@@ -31,8 +31,10 @@ import css from './ProgramIndicatorMapping.module.css'
 
 export const ProgramIndicatorMappingSection = ({
     initialProgramIndicators,
+    programName,
 }: {
     initialProgramIndicators: ProgramIndicatorWithMapping[]
+    programName?: string
 }) => {
     const programId = useParams().id
     const [programIndicators, setProgramIndicators] = React.useState<
@@ -53,6 +55,9 @@ export const ProgramIndicatorMappingSection = ({
         )
     return (
         <SectionedFormSection name="programIndicatorMappings">
+            <div className={css.programName}>
+                {i18n.t(`Program: ${programName}`, { nsSeparator: '~:~' })}
+            </div>
             <StandardFormSectionTitle>
                 {i18n.t('Program Indicator mapping')}
             </StandardFormSectionTitle>

--- a/src/pages/programDisaggregations/form/apiResponseToFormValues.ts
+++ b/src/pages/programDisaggregations/form/apiResponseToFormValues.ts
@@ -101,6 +101,12 @@ export const apiResponseToFormValues = ({
             acc[indicator.id] = {
                 ...indicator,
                 ...mappingByComboType,
+                categoryCombo:
+                    disAggCombo.name === 'default' ? undefined : disAggCombo,
+                attributeCombo:
+                    attributeCombo.name === 'default'
+                        ? undefined
+                        : attributeCombo,
             }
             return acc
         },

--- a/src/pages/programDisaggregations/form/apiResponseToFormValues.ts
+++ b/src/pages/programDisaggregations/form/apiResponseToFormValues.ts
@@ -55,6 +55,13 @@ export const apiResponseToFormValues = ({
 
     const programIndicatorMappings = programIndicators.programIndicators.reduce(
         (acc, indicator) => {
+            if (
+                indicator.categoryMappingIds.length === 0 &&
+                !indicator.aggregateExportDataElement
+            ) {
+                // skip indicators without mappings or export data element
+                return acc
+            }
             const disAggCombo = indicator.categoryCombo
             const attributeCombo = indicator.attributeCombo
 

--- a/src/pages/programDisaggregations/form/programDisaggregationSchema.ts
+++ b/src/pages/programDisaggregations/form/programDisaggregationSchema.ts
@@ -14,6 +14,7 @@ const identifiable = z.object({
 const categorySchema = identifiable.extend({
     categoryOptions: z.array(identifiable),
     dataDimensionType: z.nativeEnum(CategoryCombo.dataDimensionType),
+    name: z.string(),
 })
 const categoryComboSchema = z
     .object({

--- a/src/pages/programDisaggregations/list/ProgramListHooks.ts
+++ b/src/pages/programDisaggregations/list/ProgramListHooks.ts
@@ -8,41 +8,43 @@ import { useCallback, useState } from 'react'
 import { useBoundQueryFn } from '../../../lib'
 import { Program } from '../../../types/generated'
 
-export const PROGRAMS_GIST_QUERY_KEY = ['programs-gist'] as const
-interface ProgramsGistResponse {
+export type ProgramWithCategoryMappingsSize = {
+    displayName: string
+    name: string
+    id: string
+    categoryMappings: number
+    programIndicators: { aggregateExportDataElement?: string }[]
+}
+
+interface ProgramsDetailedResponse {
     programs: {
-        programs: Program[]
+        programs: ProgramWithCategoryMappingsSize[]
     }
 }
 
-const fields = ['name', 'displayName', 'id', 'categoryMappings'] as const
-
-export const PROGRAMS_SELECT_QUERY = {
-    resource: 'programs',
-    params: {
-        fields: [...fields],
+const PROGRAMS_DETAILED_QUERY = {
+    programs: {
+        resource: 'programs',
+        params: {
+            fields: [
+                'name',
+                'displayName',
+                'id',
+                'categoryMappings~size',
+                'programIndicators[aggregateExportDataElement]',
+            ],
+            paging: false,
+        },
     },
 }
 
 export const useProgramsWithMappingsList =
-    (): UseQueryResult<ProgramsGistResponse> => {
+    (): UseQueryResult<ProgramsDetailedResponse> => {
         const queryFn = useBoundQueryFn()
 
         return useQuery({
-            queryKey: [
-                {
-                    programs: {
-                        resource: 'programs/gist',
-                        params: {
-                            fields: [...fields],
-                            filter: ['categoryMappings:!empty'],
-                            order: 'name:asc',
-                            pagSize: 200,
-                        },
-                    },
-                },
-            ],
-            queryFn: queryFn<ProgramsGistResponse>,
+            queryKey: [PROGRAMS_DETAILED_QUERY],
+            queryFn: queryFn<ProgramsDetailedResponse>,
         })
     }
 
@@ -79,9 +81,10 @@ export const transformProgramsForSelect = (results: Program[]) =>
     )
 
 export const useProgramDeleteModal = () => {
-    const [programToDelete, setProgramToDelete] = useState<Program | null>(null)
+    const [programToDelete, setProgramToDelete] =
+        useState<ProgramWithCategoryMappingsSize | null>(null)
 
-    const open = useCallback((program: Program) => {
+    const open = useCallback((program: ProgramWithCategoryMappingsSize) => {
         setProgramToDelete(program)
     }, [])
 

--- a/src/pages/programDisaggregations/list/ProgramsList.tsx
+++ b/src/pages/programDisaggregations/list/ProgramsList.tsx
@@ -8,24 +8,32 @@ import {
     ModalContent,
     ModalTitle,
     NoticeBox,
+    SingleSelect,
+    SingleSelectOption,
 } from '@dhis2/ui'
 import React, { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { LinkButton } from '../../../components/LinkButton'
 import { LoadingSpinner } from '../../../components/loading/LoadingSpinner'
-import { ModelSingleSelect } from '../../../components/metadataFormControls/ModelSingleSelect'
 import {
-    PROGRAMS_SELECT_QUERY,
     useProgramsWithMappingsList,
     useClearMappingsMutation,
-    transformProgramsForSelect,
     useProgramDeleteModal,
+    ProgramWithCategoryMappingsSize,
 } from './ProgramListHooks'
 import classes from './ProgramsList.module.css'
 
 export const ProgramsList = () => {
     const navigate = useNavigate()
     const { data, isLoading, isError, refetch } = useProgramsWithMappingsList()
+    const programHasMappings = (p: ProgramWithCategoryMappingsSize) => {
+        return (
+            p?.categoryMappings !== 0 ||
+            p?.programIndicators?.some((pi) => pi?.aggregateExportDataElement)
+        )
+    }
+    const programsWithMappings =
+        data?.programs?.programs.filter(programHasMappings)
     const { mutateAsync: clearMappings } = useClearMappingsMutation()
     const alert = useAlert(
         ({ message }) => message,
@@ -39,12 +47,10 @@ export const ProgramsList = () => {
         isOpen: isDeleteModalOpen,
     } = useProgramDeleteModal()
 
-    const programsWithMappings = data?.programs?.programs
-
     const handleSelectChange = useCallback(
-        (selected: { id: string } | undefined) => {
-            if (selected?.id) {
-                navigate(`${selected.id}`)
+        (id: { selected: string } | undefined) => {
+            if (id?.selected) {
+                navigate(`${id.selected}`)
             }
         },
         [navigate]
@@ -70,12 +76,19 @@ export const ProgramsList = () => {
 
     return (
         <div className={classes.programsList}>
-            <ModelSingleSelect
-                query={PROGRAMS_SELECT_QUERY}
+            <SingleSelect
                 onChange={handleSelectChange}
-                transform={transformProgramsForSelect}
                 placeholder={i18n.t('Select a Program')}
-            />
+            >
+                {data?.programs?.programs?.map((program) => (
+                    <SingleSelectOption
+                        disabled={programHasMappings(program)}
+                        label={program.displayName}
+                        value={program.id}
+                        key={program.id}
+                    ></SingleSelectOption>
+                ))}
+            </SingleSelect>
 
             <h3>{i18n.t('Programs with existing mappings')}</h3>
 
@@ -146,8 +159,7 @@ export const ProgramsList = () => {
                             {i18n.t(
                                 'All mappings ({{count}}) will be removed.',
                                 {
-                                    count: programToDelete.categoryMappings
-                                        .length,
+                                    count: programToDelete.categoryMappings,
                                 }
                             )}
                         </p>

--- a/src/types/generated/models.ts
+++ b/src/types/generated/models.ts
@@ -7151,6 +7151,7 @@ export namespace ProgramDataElementDimensionItem {
 export type ProgramIndicator = {
     access: Access
     aggregateExportAttributeOptionCombo: string
+    aggregateExportDataElement: string
     aggregateExportCategoryOptionCombo: string
     aggregationType: ProgramIndicator.aggregationType
     analyticsPeriodBoundaries: Array<AnalyticsPeriodBoundary>


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-19651

This PR:
- adds a program name at the top of the page (I put this in the program indicator mapping section as I thought it looked weird as the first item outside of a section; also that made scrolling based on sidebar a bit awkward)
- update language around deletes to use `remove` and make it clearer that the mappings are being removed, not the underlying metadata objects (e.g. program indicator, category)
- update default mapping name to `Standard [category name] mapping`
- update list to include programs that have one program indicator with a `aggregateExportDataElement` value (and include in edit view of initial program indicators)
- get rid of default option from category/attribute drop downs (already represented by No value)

(note that these changes correspond mostly to individal commits, so might be easiest to look at each commit)