### PR TITLE
fix: remove soft deleted category mappings [DHIS2-19695]

### DIFF
--- a/src/pages/programDisaggregations/form/useOnSubmit.ts
+++ b/src/pages/programDisaggregations/form/useOnSubmit.ts
@@ -24,6 +24,14 @@ const cleanFormState = ({
             ([categoryId]) => !deletedCategorySet.has(categoryId)
         )
     )
+
+    // remove references to deleted mappings (note: you cannot delete all mappings through UI)
+    for (const cat in cleanedCategoryMappings) {
+        cleanedCategoryMappings[cat] = cleanedCategoryMappings[cat].filter(
+            (individualMapping) => !individualMapping.deleted
+        )
+    }
+
     const categoryMappingsSet = new Set(
         Object.values(cleanedCategoryMappings).flatMap((categoryMapping) =>
             categoryMapping.map((cm) => cm.id)


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-19729

Soft deleted individual mappings were not being removed on save. This ticket updates the logic for cleaning up categoryMappings to filter out soft deleted individual mappings