### PR TITLE
fix: make attribute object selections filterable

### DIFF
--- a/src/pages/attributes/form/AttributeTypeComponent.tsx
+++ b/src/pages/attributes/form/AttributeTypeComponent.tsx
@@ -194,6 +194,7 @@ export const AttributeTypeComponent = ({
 
     return (
         <MultiSelectField
+            filterable={true}
             dataTest="formfields-objecttypes"
             label={i18n.t('Objects to which this attribute can be applied')}
             selected={selections}


### PR DESCRIPTION
@karolinelien pointed out that the ticket https://dhis2.atlassian.net/browse/DHIS2-19842 called for the attribute objects to be searchable, so I've added that:

<img width="380" height="277" alt="image" src="https://github.com/user-attachments/assets/a04ccadd-0cf8-4329-a884-f25b27712d11" />
