### PR TITLE
fix: ns separator and indicator form timeouts

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,14 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-09-04T14:58:58.085Z\n"
-"PO-Revision-Date: 2025-09-04T14:58:58.086Z\n"
-"POT-Creation-Date: 2025-08-27T11:13:59.823Z\n"
-"PO-Revision-Date: 2025-08-27T11:13:59.824Z\n"
-"POT-Creation-Date: 2025-08-25T12:21:51.518Z\n"
-"PO-Revision-Date: 2025-08-25T12:21:51.518Z\n"
-"POT-Creation-Date: 2025-08-26T14:47:52.498Z\n"
-"PO-Revision-Date: 2025-08-26T14:47:52.499Z\n"
+"POT-Creation-Date: 2025-09-10T08:00:57.421Z\n"
+"PO-Revision-Date: 2025-09-10T08:00:57.421Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -220,6 +214,11 @@ msgstr "Correct confirmation code must be entered to merge"
 
 msgid "Merge"
 msgstr "Merge"
+
+msgid "Merging {{count}} {{model}}..."
+msgid_plural "Merging {{count}} {{model}}..."
+msgstr[0] "Merging {{count}} {{model}}..."
+msgstr[1] "Merging {{count}} {{model}}..."
 
 msgid "Merging..."
 msgstr "Merging..."
@@ -1256,8 +1255,8 @@ msgstr "Program name"
 msgid "Decimals in data output"
 msgstr "Decimals in data output"
 
-msgid "value"
-msgstr "value"
+msgid "Value"
+msgstr "Value"
 
 msgid "Mandatory"
 msgstr "Mandatory"
@@ -1496,6 +1495,11 @@ msgstr "Filter available categories"
 msgid "Filter selected categories"
 msgstr "Filter selected categories"
 
+msgid "{{count}} category option combinations will be generated."
+msgid_plural "{{count}} category option combinations will be generated."
+msgstr[0] "{{count}} category option combinations will be generated."
+msgstr[1] "{{count}} category option combinations will be generated."
+
 msgid "More than 4 Categories"
 msgstr "More than 4 Categories"
 
@@ -1666,6 +1670,16 @@ msgid ""
 msgstr ""
 "What should happen to the source category options after the merge is "
 "complete?"
+
+msgid "Keep {{ count }} source category options"
+msgid_plural "Keep {{ count }} source category options"
+msgstr[0] "Keep {{ count }} source category options"
+msgstr[1] "Keep {{ count }} source category options"
+
+msgid "Delete {{ count }} source category options"
+msgid_plural "Delete {{ count }} source category options"
+msgstr[0] "Delete {{ count }} source category options"
+msgstr[1] "Delete {{ count }} source category options"
 
 msgid "Available data element groups"
 msgstr "Available data element groups"
@@ -2027,6 +2041,12 @@ msgstr "Line end"
 msgid "Section display mode"
 msgstr "Section display mode"
 
+msgid "Single page: all sections shown consecutively in one form"
+msgstr "Single page: all sections shown consecutively in one form"
+
+msgid "Tabs: show a tab for each section"
+msgstr "Tabs: show a tab for each section"
+
 msgid "Horizontal tabs"
 msgstr "Horizontal tabs"
 
@@ -2313,6 +2333,15 @@ msgstr "Disable automatic grouping of data elements"
 msgid "Display mode"
 msgstr "Display mode"
 
+msgid "Default: data elements as rows, categories as columns"
+msgstr "Default: data elements as rows, categories as columns"
+
+msgid "Pivot: categories as rows, data elements as columns"
+msgstr "Pivot: categories as rows, data elements as columns"
+
+msgid "Move a category to rows: default mode with one category moved to rows"
+msgstr "Move a category to rows: default mode with one category moved to rows"
+
 msgid "Category to move to rows"
 msgstr "Category to move to rows"
 
@@ -2502,6 +2531,16 @@ msgstr ""
 "What should happen to the source indicator types after the merge is "
 "complete?"
 
+msgid "Keep {{ count }} source indicator types"
+msgid_plural "Keep {{ count }} source indicator types"
+msgstr[0] "Keep {{ count }} source indicator types"
+msgstr[1] "Keep {{ count }} source indicator types"
+
+msgid "Delete {{ count }} source indicator types"
+msgid_plural "Delete {{ count }} source indicator types"
+msgstr[0] "Delete {{ count }} source indicator types"
+msgstr[1] "Delete {{ count }} source indicator types"
+
 msgid "Conflicting factors"
 msgstr "Conflicting factors"
 
@@ -2667,6 +2706,16 @@ msgstr "No indicators available. Remove one from source."
 msgid "What should happen to the source indicators after the merge is complete?"
 msgstr "What should happen to the source indicators after the merge is complete?"
 
+msgid "Keep {{ count }} source indicators"
+msgid_plural "Keep {{ count }} source indicators"
+msgstr[0] "Keep {{ count }} source indicators"
+msgstr[1] "Keep {{ count }} source indicators"
+
+msgid "Delete {{ count }} source indicators"
+msgid_plural "Delete {{ count }} source indicators"
+msgstr[0] "Delete {{ count }} source indicators"
+msgstr[1] "Delete {{ count }} source indicators"
+
 msgid "Set up the basic information for this option group set."
 msgstr "Set up the basic information for this option group set."
 
@@ -2696,6 +2745,9 @@ msgstr "Set up the basic information for this option group."
 
 msgid "Explain the purpose of this option group."
 msgstr "Explain the purpose of this option group."
+
+msgid "Options"
+msgstr "Options"
 
 msgid "Select the options that belong to this group."
 msgstr "Select the options that belong to this group."
@@ -3216,6 +3268,11 @@ msgstr "Delete Mapping"
 
 msgid "This action cannot be undone."
 msgstr "This action cannot be undone."
+
+msgid "All mappings ({{count}}) will be removed."
+msgid_plural "All mappings ({{count}}) will be removed."
+msgstr[0] "All mappings ({{count}}) will be removed."
+msgstr[1] "All mappings ({{count}}) will be removed."
 
 msgid "Are you sure you want to delete this program mapping configuration?"
 msgstr "Are you sure you want to delete this program mapping configuration?"

--- a/src/pages/dataSetsWip/form/DisplayOptionsField.tsx
+++ b/src/pages/dataSetsWip/form/DisplayOptionsField.tsx
@@ -128,7 +128,8 @@ export function DisplayOptionsField({
                         }}
                         onBlur={renderAsTabs.onBlur}
                         label={i18n.t(
-                            'Single page: all sections shown consecutively in one form'
+                            'Single page: all sections shown consecutively in one form',
+                            { nsSeparator: '~:~' }
                         )}
                     />
                     <Radio
@@ -137,7 +138,9 @@ export function DisplayOptionsField({
                             renderAsTabs.input.onChange(checked)
                         }}
                         onBlur={renderAsTabs.onBlur}
-                        label={i18n.t('Tabs: show a tab for each section')}
+                        label={i18n.t('Tabs: show a tab for each section', {
+                            nsSeparator: '~:~',
+                        })}
                     />
                     {!!renderAsTabs.input.value && (
                         <div className={classes.renderAsTabsOptions}>

--- a/src/pages/dataSetsWip/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
+++ b/src/pages/dataSetsWip/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
@@ -451,7 +451,8 @@ export const DataSetSectionFormContents = ({
                                     <StandardFormField>
                                         <RadioFieldFF
                                             label={i18n.t(
-                                                'Default: data elements as rows, categories as columns'
+                                                'Default: data elements as rows, categories as columns',
+                                                { nsSeparator: '~:~' }
                                             )}
                                             input={
                                                 defaultDisplayModeField.input
@@ -462,7 +463,8 @@ export const DataSetSectionFormContents = ({
                                     <StandardFormField>
                                         <RadioFieldFF
                                             label={i18n.t(
-                                                'Pivot: categories as rows, data elements as columns'
+                                                'Pivot: categories as rows, data elements as columns',
+                                                { nsSeparator: '~:~' }
                                             )}
                                             input={pivotDisplayModeField.input}
                                             meta={pivotDisplayModeField.meta}
@@ -471,7 +473,8 @@ export const DataSetSectionFormContents = ({
                                     <StandardFormField>
                                         <RadioFieldFF
                                             label={i18n.t(
-                                                'Move a category to rows: default mode with one category moved to rows'
+                                                'Move a category to rows: default mode with one category moved to rows',
+                                                { nsSeparator: '~:~' }
                                             )}
                                             input={
                                                 moveCategoriesDisplayModeField.input

--- a/src/pages/indicators/Form.spec.tsx
+++ b/src/pages/indicators/Form.spec.tsx
@@ -21,6 +21,8 @@ import { Component as Edit } from './Edit'
 import { Component as New } from './New'
 import resetAllMocks = jest.resetAllMocks
 
+jest.setTimeout(40 * 1000) // set timeout to 40 seconds for these tests
+
 const section = SECTIONS_MAP.indicator
 const mockSchema = schemaMock
 


### PR DESCRIPTION
This PR fixes two issues:
- adds non-default nsSeparator to strings containing a `:`, such that they can be properly scanned by i18next-scanner
- increases time out on indicator form tests (they run fine locally but timeout in CI run)