### PR TITLE
fix: program indicator disaggregation min version

### DIFF
--- a/src/lib/constants/sections.ts
+++ b/src/lib/constants/sections.ts
@@ -431,7 +431,7 @@ export const NON_SCHEMA_SECTION = {
         title: i18n.t('Program disaggregation'),
         titlePlural: i18n.t('Program disaggregations'),
         parentSectionKey: 'other',
-        minApiVersion: 43,
+        minApiVersion: 42,
         authorities: [
             {
                 type: SchemaAuthorityType.CREATE_PUBLIC,


### PR DESCRIPTION
This fixes mistake where I put the minimum api version for program indicator disaggregation UI as v43, whereas it should have been v42