### PR TITLE
fix: add aggregateExportDataElement into list

### DIFF
--- a/src/lib/constants/translatedModelProperties.ts
+++ b/src/lib/constants/translatedModelProperties.ts
@@ -8,6 +8,9 @@ const TRANSLATED_PROPERTY: Record<string, string> = {
     aggregateExportAttributeOptionCombo: i18n.t(
         'Attribute option combination for aggregate data export'
     ),
+    aggregateExportDataElement: i18n.t(
+        'Data element for aggregate data export'
+    ),
     analyticsType: i18n.t('Analytics type'),
     category: i18n.t('Category'),
     categoryCombo: i18n.t('Category combination'),

--- a/src/lib/sectionList/listViews/sectionListViewsConfig.ts
+++ b/src/lib/sectionList/listViews/sectionListViewsConfig.ts
@@ -460,6 +460,7 @@ export const modelListViewsConfig = {
                 'filter',
                 'aggregateExportCategoryOptionCombo',
                 'aggregateExportAttributeOptionCombo',
+                'aggregateExportDataElement',
             ],
         },
         filters: {


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-17306

Adds `aggregateExportDataElement` in programIndicator list.
<img width="1132" height="208" alt="image" src="https://github.com/user-attachments/assets/35587f8e-c1be-4ba4-966c-22090e807615" />
