### PR TITLE
fix: add property for edit

### DIFF
--- a/src/pages/dataSetNotificationTemplates/Edit.tsx
+++ b/src/pages/dataSetNotificationTemplates/Edit.tsx
@@ -41,6 +41,7 @@ const fieldFilters = [
     'recipientUserGroup[id,displayName]',
     'deliveryChannels',
     'dataSets[id,name,displayName]',
+    'notifyUsersInHierarchyOnly',
 ] as const
 
 type DataSetNotificationResult = PickWithFieldFilters<


### PR DESCRIPTION
fixes issue pointed out here https://dhis2.atlassian.net/browse/DHIS2-1878?focusedCommentId=222513

Forgot to add property in edit page, so it didn't appear when you opened up for edit.

This PR fixes that:

<img width="731" height="443" alt="image" src="https://github.com/user-attachments/assets/563347b8-fd58-4c87-ad27-3f7870caf2b5" />
